### PR TITLE
Change to the next existing audio-device

### DIFF
--- a/pulseaudio-control.sh
+++ b/pulseaudio-control.sh
@@ -98,32 +98,31 @@ function volMute {
 
 }
 
-# Changing the audio device, from 
+# change the audio Device
 function changeDevice {
     # Treats pulseaudio sink list to avoid calling pacmd list-sinks twice
     o_pulseaudio=$(pacmd list-sinks| grep -e 'index' -e 'device.description')
 
-    # Gets max sink index
-    nSinks=$(echo "$o_pulseaudio" | grep index | cut -d: -f2 | sed '$!d')
+    # Gets all sink indices
+    sinks=$(echo "$o_pulseaudio" | grep index | cut -d: -f2)
 
     # Gets present default sink index
     activeSink=$(echo "$o_pulseaudio" | grep "\* index" | cut -d: -f2)
 
     # Sets new sink index, checks that it's not in the blacklist
     newSink=$activeSink
-    i=0
-    found=0
-    while [ $i -le "$nSinks" ] && [ "$found" -ne 1 ]; do
-        found=1
-        newSink=$((newSink + 1))
-        if [ "$newSink" -gt "$nSinks" ]; then newSink=0; fi
-        for el in "${SINK_BLACKLIST[@]}"; do
-            if [ "$el" -eq "${newSink}" ]; then 
-                found=0
-                break
-            fi
-        done
-        i=$((i+1))
+    for sink in $sinks; do
+        if [ $sink -eq $activeSink ]; then
+            continue
+        else
+            for el in "${SINK_BLACKLIST[@]}"; do
+                if [ "$el" -eq "${sink}" ]; then
+                    continue
+                fi
+            done
+        fi
+
+        newSink=$sink
     done
 
     # New sink


### PR DESCRIPTION
In cases, where audio-devices come and go during the uptime, gaps in the indices of pulseaudio indices occur. This change loops over the existing indices with no knowledge of continuity or so.

This happens on my machine when the bluetooth-headset disconnects due to distance. So, every time I get a coffee/tea. This change - working on my machine - addresses that.