### PR TITLE
Run pactl with preset language

### DIFF
--- a/pulseaudio-control.sh
+++ b/pulseaudio-control.sh
@@ -160,7 +160,7 @@ function sendNotification {
 function listen {
     firstrun=0
 
-    pactl subscribe 2>/dev/null | {
+    LANG=$LANGUAGE pactl subscribe 2>/dev/null | {
         while true; do
             {
                 # If this is the first time just continue


### PR DESCRIPTION
pactl runs with system language while script expects english. pactl has to be ran with language set to english. Otherwise, it will not update changes such as volume level, mute on/off.