### PR TITLE
Human readable names

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,6 +36,7 @@ You can change the script configuration at the beginning of the file:
 | `DEFAULT_SINK_ICON` | String\*         | Icon used for the sink. |
 | `CUSTOM_SINK_ICON`  | String\*         | Custom icons for each of your sinks. If a custom icon isn't found, the default one will be used instead. |
 | `NOTIFICATIONS`     | `"yes"` / `"no"` | Sends a notifcation when the sink is changed. |
+| `NICKNAMES`         | `"yes"` / `"no"` | Uses self-defined names or pulseaudios device descriptions instead of sink-indices. |
 | `SINK_BLACKLIST`    | Bash array like `( 0 1 2 )` | A blacklist for whenever you switch sinks. You should put in the array the indexes of the devices you want to blaclist. Use `pacmd list-sinks` to see all device names in order to get its index. The list should also be sorted for a small performance improvement. |
 
 \*Check the [Useful icons](#useful-icons) section for examples.

--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ You can change the script configuration at the beginning of the file:
 | `CUSTOM_SINK_ICON`     | String\*         | Custom icons for each of your sinks. If a custom icon isn't found, the default one will be used instead. |
 | `NOTIFICATIONS`        | `"yes"` / `"no"` | Sends a notifcation when the sink is changed. |
 | `SINK_BLACKLIST`       | Bash array like `( 0 1 2 )` | A blacklist for whenever you switch sinks. You should put in the array the indexes of the devices you want to blaclist. Use `pacmd list-sinks` to see all device names in order to get its index. The list should also be sorted for a small performance improvement. |
-| `NAME_DISPLAYNAME_MAP` | Bash associative array | Maps the pulseaudio name of a sink to a human-readable displayname to be used in the statusbar. |
+| `DISPLAY_NAMES`        | Bash associative array | Maps the pulseaudio name of a sink to a human-readable displayname to be used in the statusbar. |
 
 \*Check the [Useful icons](#useful-icons) section for examples.
 

--- a/README.md
+++ b/README.md
@@ -24,20 +24,20 @@ To be able to switch the default sinks from this script you might need to disabl
 
 You can change the script configuration at the beginning of the file:
 
-| Name                |  Values          | Description |
-| ------------------- | :--------------: | ----------- |
-| `OSD`               | `"yes"` / `"no"` | Will display an OSD message when changing volume if set to true. |
-| `INC`               | Numerical        | Sets the increment/decrease that each volume up/down will perform. |
-| `MAX_VOL`           | Numerical        | Maximum volume. |
-| `AUTOSYNC`          | `"yes"` / `"no"` | Will automatically sync all program volumes with the volume of your current sink (output) whenever you change the volume. This is useful if you manage multiple outputs and have issues with the app volumes becoming out of sync with the output. |
-| `VOLUME_ICONS`      | Bash array like `( "🔉" "🔊" )` with strings\* | Icons used for the volume (ordered by sound level). The volume levels are divided by the number of icons inside it. For example, if you are using 4 icons and `MAX_VOL` is 100, they will show up in order when the volume is lower than 25, 50, 75 and 100. This is useful because some fonts only have 2 volume levels while others can have up to 4. |
-| `MUTED_ICON`        | String\*         | Icon used for the muted volume. |
-| `MUTED_COLOR`       | Polybar color    | Color used when the audio is muted. |
-| `DEFAULT_SINK_ICON` | String\*         | Icon used for the sink. |
-| `CUSTOM_SINK_ICON`  | String\*         | Custom icons for each of your sinks. If a custom icon isn't found, the default one will be used instead. |
-| `NOTIFICATIONS`     | `"yes"` / `"no"` | Sends a notifcation when the sink is changed. |
-| `NICKNAMES`         | `"yes"` / `"no"` | Uses self-defined names or pulseaudios device descriptions instead of sink-indices. |
-| `SINK_BLACKLIST`    | Bash array like `( 0 1 2 )` | A blacklist for whenever you switch sinks. You should put in the array the indexes of the devices you want to blaclist. Use `pacmd list-sinks` to see all device names in order to get its index. The list should also be sorted for a small performance improvement. |
+| Name                   |  Values          | Description |
+| ---------------------- | :--------------: | ----------- |
+| `OSD`                  | `"yes"` / `"no"` | Will display an OSD message when changing volume if set to true. |
+| `INC`                  | Numerical        | Sets the increment/decrease that each volume up/down will perform. |
+| `MAX_VOL`              | Numerical        | Maximum volume. |
+| `AUTOSYNC`             | `"yes"` / `"no"` | Will automatically sync all program volumes with the volume of your current sink (output) whenever you change the volume. This is useful if you manage multiple outputs and have issues with the app volumes becoming out of sync with the output. |
+| `VOLUME_ICONS`         | Bash array like `( "🔉" "🔊" )` with strings\* | Icons used for the volume (ordered by sound level). The volume levels are divided by the number of icons inside it. For example, if you are using 4 icons and `MAX_VOL` is 100, they will show up in order when the volume is lower than 25, 50, 75 and 100. This is useful because some fonts only have 2 volume levels while others can have up to 4. |
+| `MUTED_ICON`           | String\*         | Icon used for the muted volume. |
+| `MUTED_COLOR`          | Polybar color    | Color used when the audio is muted. |
+| `DEFAULT_SINK_ICON`    | String\*         | Icon used for the sink. |
+| `CUSTOM_SINK_ICON`     | String\*         | Custom icons for each of your sinks. If a custom icon isn't found, the default one will be used instead. |
+| `NOTIFICATIONS`        | `"yes"` / `"no"` | Sends a notifcation when the sink is changed. |
+| `SINK_BLACKLIST`       | Bash array like `( 0 1 2 )` | A blacklist for whenever you switch sinks. You should put in the array the indexes of the devices you want to blaclist. Use `pacmd list-sinks` to see all device names in order to get its index. The list should also be sorted for a small performance improvement. |
+| `NAME_DISPLAYNAME_MAP` | Bash associative array | Maps the pulseaudio name of a sink to a human-readable displayname to be used in the statusbar. |
 
 \*Check the [Useful icons](#useful-icons) section for examples.
 

--- a/pulseaudio-control.bash
+++ b/pulseaudio-control.bash
@@ -60,11 +60,11 @@ function getCurName() {
 # Saves a `nickname` for the sink passed by parameter into a variable called `curNick`.
 # If a mapping for the sink name exists, that is used. Otherwise, the sinks description is used as fallback.
 function getCurNick() {
-  getCurName $1
+  getCurName "$1"
   if [ ${NAME_NICKNAME_MAP[$curName]+abc} ]; then
     curNick="${NAME_NICKNAME_MAP[$curName]}"
   else
-    getCurDescr $1
+    getCurDescr "$1"
     curNick="$curDescr"
   fi
 }
@@ -198,10 +198,10 @@ function changeDevice() {
     done
 
     if [ $NOTIFICATIONS = "yes" ]; then
-        getCurDescr $newSink
+        getCurDescr "$newSink"
         displayName="${curDescr}"
         if [ $NICKNAMES = "yes" ]; then
-          getCurNick $newSink
+          getCurNick "$newSink"
           displayName="${curNick}"
         fi
         notify-send "PulseAudio" "Changed output to $displayName" --icon=audio-headphones-symbolic &

--- a/pulseaudio-control.bash
+++ b/pulseaudio-control.bash
@@ -199,7 +199,12 @@ function changeDevice() {
 
     if [ $NOTIFICATIONS = "yes" ]; then
         getCurDescr $newSink
-        notify-send "PulseAudio" "Changed output to $curDescr" --icon=audio-headphones-symbolic &
+        displayName="${curDescr}"
+        if [ $NICKNAMES = "yes" ]; then
+          getCurNick $newSink
+          displayName="${curNick}"
+        fi
+        notify-send "PulseAudio" "Changed output to $displayName" --icon=audio-headphones-symbolic &
     fi
 }
 

--- a/pulseaudio-control.bash
+++ b/pulseaudio-control.bash
@@ -198,11 +198,12 @@ function changeDevice() {
     done
 
     if [ $NOTIFICATIONS = "yes" ]; then
-        getCurDescr "$newSink"
-        displayName="${curDescr}"
         if [ $NICKNAMES = "yes" ]; then
           getCurNick "$newSink"
-          displayName="${curNick}"
+          displayName="$curNick"
+        else
+          getCurDescr "$newSink"
+          displayName="$curDescr"
         fi
         notify-send "PulseAudio" "Changed output to $displayName" --icon=audio-headphones-symbolic &
     fi
@@ -281,10 +282,10 @@ function output() {
         sinkIcon=$DEFAULT_SINK_ICON
     fi
 
-    local displayName="${curSink}"
+    local displayName="$curSink"
     if [ $NICKNAMES = "yes" ]; then
       getCurNick "$curSink"
-      displayName="${curNick}"
+      displayName="$curNick"
     fi
 
     # Showing the formatted message

--- a/pulseaudio-control.bash
+++ b/pulseaudio-control.bash
@@ -13,14 +13,14 @@ AUTOSYNC="no"  # All programs have the same volume if enabled
 VOLUME_ICONS=( "# " "# " "# " )  # Volume icons array, from lower volume to higher
 MUTED_ICON="# "  # Muted volume icon
 MUTED_COLOR="%{F#6b6b6b}"  # Color when the audio is muted
-DEFAULT_SINK_ICON="# "  # The default sink icon if a custom one isn't found
+DEFAULT_SINK_ICON=""  # The default sink icon if a custom one isn't found
 CUSTOM_SINK_ICONS=(  )  # Custom sink icons in index of sink order
 NOTIFICATIONS="no"  # Notifications when switching sinks if enabled
 SINK_BLACKLIST=(  )  # Index blacklist for sinks when switching between them
 
 # maps pulse-audio sink names to human-readable names
-declare -A NAME_DISPLAYNAME_MAP
-NAME_DISPLAYNAME_MAP["alsa_output.usb-SomeManufacturer_SomeUsbSoundcard-00.analog-stereo"]="External Soundcard"
+declare -A DISPLAY_NAMES
+DISPLAY_NAMES["alsa_output.usb-SomeManufacturer_SomeUsbSoundcard-00.analog-stereo"]="External Soundcard"
 
 
 # Environment & global constants for the scriot
@@ -52,10 +52,10 @@ function getCurName() {
 # If a mapping for the sink name exists, that is used. Otherwise, the string "Sink <index>" is used.
 function getDisplayName() {
   getCurName "$1"
-  if [ ${NAME_DISPLAYNAME_MAP[$curName]+abc} ]; then
-    displayName="${NAME_DISPLAYNAME_MAP[$curName]}"
+  if [ ${DISPLAY_NAMES[$curName]+abc} ]; then
+    displayName="${DISPLAY_NAMES[$curName]}"
   else
-    displayName="Sink $1"
+    displayName="Sink #$1"
   fi
 }
 


### PR DESCRIPTION
I (mainly for myself) implemented the possibility to display a name for the current sink, as  the indices change and I can't remember which is which :)
The functionality either uses the "device.description" property as a fallback name or a name supplied from a lookup table that maps the pulseaudio sink name (which is expected to be stable) to a custom name.

Feel free to reject if this isn't the direction you'd like to go, but I thought I'd share my adjustments, maybe you're interested. I probably will implement something similar for the icon mapping, also based on the pulseaudio sink name instead of the index.