### PR TITLE
Add bash minimum version to readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,6 +19,10 @@ To be able to switch the default sinks from this script you might need to disabl
 
 `load-module module-stream-restore restore_device=false`
 
+At a minimum, bash version 4 is required to run the script. You can check your bash version by running:
+
+`bash --version`
+
 
 ## Configuration
 


### PR DESCRIPTION
Associative arrays (maps as mentioned in #28) were introduced in [bash 4](https://www.tldp.org/LDP/abs/html/bashver4.html).

I hope this addition to the readme is appropriate!