### PR TITLE
Fix shebang

### DIFF
--- a/pulseaudio-control.bash
+++ b/pulseaudio-control.bash
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 ##################################################################
 # Polybar Pulseaudio Control                                     #


### PR DESCRIPTION
Hi,

Thanks a lot for your script! However, it didn't work for me as `bash` isn't in `/bin/` on my distribution. When using bash, it's recommended to use `/usr/bin/env bash` (See https://stackoverflow.com/questions/21612980/why-is-usr-bin-env-bash-superior-to-bin-bash/21613044).

This PR should allow more portability.


Side note: It's perfectly fine to use `/bin/sh` because POSIX requires to have `/bin/sh` available but bash isn't required to be there.