### PR TITLE
Replace changed sink notification instead of accumulating

### DIFF
--- a/pulseaudio-control.bash
+++ b/pulseaudio-control.bash
@@ -211,9 +211,14 @@ function nextSink() {
         pacmd move-sink-input "$i" "$newSink"
     done
 
+    notify="notify-send"
+    if command -v dunstify &>/dev/null; then
+        notify="dunstify --replace 201839192"
+    fi
+
     if [ $NOTIFICATIONS = "yes" ]; then
         getNickname "$newSink"
-        notify-send "PulseAudio" "Changed output to $nickname" --icon=audio-headphones-symbolic &
+        $notify "PulseAudio" "Changed output to $nickname" --icon=audio-headphones-symbolic &
     fi
 }
 

--- a/pulseaudio-control.bash
+++ b/pulseaudio-control.bash
@@ -211,7 +211,6 @@ function nextSink() {
         pacmd move-sink-input "$i" "$newSink"
     done
 
-
     if [ $NOTIFICATIONS = "yes" ]; then
         getNickname "$newSink"
         

--- a/pulseaudio-control.bash
+++ b/pulseaudio-control.bash
@@ -211,13 +211,15 @@ function nextSink() {
         pacmd move-sink-input "$i" "$newSink"
     done
 
-    notify="notify-send"
-    if command -v dunstify &>/dev/null; then
-        notify="dunstify --replace 201839192"
-    fi
 
     if [ $NOTIFICATIONS = "yes" ]; then
         getNickname "$newSink"
+        
+        if command -v dunstify &>/dev/null; then
+            notify="dunstify --replace 201839192"
+        else
+            notify="notify-send"
+        fi
         $notify "PulseAudio" "Changed output to $nickname" --icon=audio-headphones-symbolic &
     fi
 }


### PR DESCRIPTION
If the user has `dunstify` installed we should replace old notifications instead of letting them accumulate in the notification center.