### PR TITLE
Add active port to Sink Name

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,8 +39,8 @@ You can change the script configuration at the beginning of the file:
 | `MUTED_COLOR`          | String ([polybar color](https://github.com/polybar/polybar/wiki/Formatting#foreground-color-f))   | Color used when the audio is muted. |
 | `NOTIFICATIONS`        | `"yes"` / `"no"`         | Sends a notification when the sink is changed. |
 | `SINK_ICON`            | String\*                 | Icon always displayed to the left of the sink names. |
-| `SINK_BLACKLIST`       | Bash array               | A blacklist for whenever sinks are switched. Use `pactl list sinks short` to see all active sink names. |
-| `SINK_NICKNAMES`       | Bash associative array   | Maps the PulseAudio sink names to human-readable nicknames. Use `pactl list sinks short` to obtain the active sinks names. If unconfigured, `Sink #N` is used instead. Custom icons\* for the sinks can be added here if `SINK_ICON` is set to `""`. |
+| `SINK_BLACKLIST`       | Bash array               | A blacklist for whenever sinks are switched. Use `pactl list sinks | awk '/Sink/{flag=1; next} flag && /Name:/{printf $2"/"} flag && /Active Port:/{print $NF; flag=0;}'` to see all active sink names. |
+| `SINK_NICKNAMES`       | Bash associative array   | Maps the PulseAudio sink names to human-readable nicknames. Use `pactl list sinks | awk '/Sink/{flag=1; next} flag && /Name:/{printf $2"/"} flag && /Active Port:/{print $NF; flag=0;}'` to obtain the active sinks names. If unconfigured, `Sink #N` is used instead. Custom icons\* for the sinks can be added here if `SINK_ICON` is set to `""`. |
 
 \*Check the [Useful icons](#useful-icons) section for examples.
 

--- a/README.md
+++ b/README.md
@@ -39,11 +39,20 @@ You can change the script configuration at the beginning of the file:
 | `MUTED_COLOR`          | String ([polybar color](https://github.com/polybar/polybar/wiki/Formatting#foreground-color-f))   | Color used when the audio is muted. |
 | `NOTIFICATIONS`        | `"yes"` / `"no"`         | Sends a notification when the sink is changed. |
 | `SINK_ICON`            | String\*                 | Icon always displayed to the left of the sink names. |
-| `SINK_BLACKLIST`       | Bash array               | A blacklist for whenever sinks are switched. Use `pactl list sinks | awk '/Sink/{flag=1; next} flag && /Name:/{printf $2"/"} flag && /Active Port:/{print $NF; flag=0;}'` to see all active sink names. |
-| `SINK_NICKNAMES`       | Bash associative array   | Maps the PulseAudio sink names to human-readable nicknames. Use `pactl list sinks | awk '/Sink/{flag=1; next} flag && /Name:/{printf $2"/"} flag && /Active Port:/{print $NF; flag=0;}'` to obtain the active sinks names. If unconfigured, `Sink #N` is used instead. Custom icons\* for the sinks can be added here if `SINK_ICON` is set to `""`. |
+| `SINK_BLACKLIST`       | Bash array               | A blacklist for whenever sinks are switched. Check [Sink Nicknames](#sink-nicknames) to see all active sink names. |
+| `SINK_NICKNAMES`       | Bash associative array   | Maps the PulseAudio sink names to human-readable nicknames. Check [Sink Nicknames](#sink-nicknames) to obtain the active sinks names. If unconfigured, `Sink #N` is used instead. Custom icons\* for the sinks can be added here if `SINK_ICON` is set to `""`. |
 
 \*Check the [Useful icons](#useful-icons) section for examples.
 
+### Sink Nicknames
+To get sink nicknames, run this command
+```
+pactl list sinks | awk -v sink="Sink" \
+        '$0 ~ sink {flag=1; next} \
+         flag && /Name:/{printf $2"/"; next} \
+         flag && /Active Port:/{ print $NF; flag=0;}
+         flag && /^$/{print;flag=0}'
+```
 
 ## Module
 

--- a/pulseaudio-control.bash
+++ b/pulseaudio-control.bash
@@ -54,9 +54,9 @@ function getCurVol() {
 # ie. `<name>/`
 function getSinkName() {
     sinkName=$(pactl list sinks | awk -v sink="Sink #$1" \
-        '$0 == sink {flag=1; next} \
-         flag && /Name:/{printf $2"/"; next} \
-         flag && /Active Port:/{print $NF; flag=0;} \
+        '$0 == sink {flag=1; next}
+         flag && /Name:/{printf $2"/"; next}
+         flag && /Active Port:/{print $NF; flag=0;}
          flag && /^$/ {print; flag=0}')
 }
 

--- a/pulseaudio-control.bash
+++ b/pulseaudio-control.bash
@@ -48,8 +48,10 @@ function getCurVol() {
 
 # Saves the name of the sink passed by parameter into a variable named
 # `sinkName`.
+# Runs `pactl list sinks` and extracts the `Name` and `Active Port` for the sink number given
+# as the argument to the function. Then combine them with a /. ie. `name/active_port`
 function getSinkName() {
-    sinkName=$(pactl list sinks | awk -v sink="Sink #$1" '$0 ~ sink {flag=1; next} flag && /Name:/{printf $2"/"} flag && /Active Port:/{print $NF; flag=0;}')
+    sinkName=$(pactl list sinks | awk -v sink="Sink #$1" '$0 == sink {flag=1; next} flag && /Name:/{printf $2"/"; next} flag && /Active Port:/{print $NF; flag=0;}')
 }
 
 

--- a/pulseaudio-control.bash
+++ b/pulseaudio-control.bash
@@ -49,9 +49,15 @@ function getCurVol() {
 # Saves the name of the sink passed by parameter into a variable named
 # `sinkName`.
 # Runs `pactl list sinks` and extracts the `Name` and `Active Port` for the sink number given
-# as the argument to the function. Then combine them with a /. ie. `name/active_port`
+# as the argument to the function. Then combine them with a /. ie. `<name>/<active_port>`
+# If the Sink doesn't have an active port, this will just append a / to the name
+# ie. `<name>/`
 function getSinkName() {
-    sinkName=$(pactl list sinks | awk -v sink="Sink #$1" '$0 == sink {flag=1; next} flag && /Name:/{printf $2"/"; next} flag && /Active Port:/{print $NF; flag=0;}')
+    sinkName=$(pactl list sinks | awk -v sink="Sink #$1" \
+        '$0 == sink {flag=1; next} \
+         flag && /Name:/{printf $2"/"; next} \
+         flag && /Active Port:/{print $NF; flag=0;} \
+         flag && /^$/ {print; flag=0}')
 }
 
 

--- a/pulseaudio-control.bash
+++ b/pulseaudio-control.bash
@@ -49,7 +49,7 @@ function getCurVol() {
 # Saves the name of the sink passed by parameter into a variable named
 # `sinkName`.
 function getSinkName() {
-    sinkName=$(pactl list sinks short | awk -v sink="$1" '{ if ($1 == sink) {print $2} }')
+    sinkName=$(pactl list sinks | awk -v sink="Sink #$1" '$0 ~ sink {flag=1; next} flag && /Name:/{printf $2"/"} flag && /Active Port:/{print $NF; flag=0;}')
 }
 
 

--- a/tests.bats
+++ b/tests.bats
@@ -174,7 +174,7 @@ function setup() {
     # Populating part of the map.
     SINK_NICKNAMES["does-not-exist"]="null"
     for i in {0..4}; do
-        SINK_NICKNAMES["null-sink-$i"]="Null Sink $i"
+        SINK_NICKNAMES["null-sink-$i/"]="Null Sink $i"
         getNickname "$((i + offset))"
         [ "$nickname" = "Null Sink $i" ]
     done


### PR DESCRIPTION
Pulse audio can have multiple ports per sink. If you plug in headphones, it uses the same sink with a different port. This change will add the active port to the sink like below.
```
alsa_output.pci-0000_00_1f.3.analog-stereo/analog-output-speaker
bluez_sink.04_5D_4B_65_F7_1F.a2dp_sink/headset-output
```
With this, it is possible to have different sink nickname for when a wired headphone is connected.