### PR TITLE
Make sure only one integer value is returned

### DIFF
--- a/pulseaudio-control.bash
+++ b/pulseaudio-control.bash
@@ -42,7 +42,7 @@ function getCurSink() {
 
 # Saves the sink passed by parameter's volume into a variable named `curVol`.
 function getCurVol() {
-    curVol=$(pacmd list-sinks | grep -A 15 'index: '"$1"'' | grep 'volume:' | grep -E -v 'base volume:' | awk -F : '{print $3}' | grep -o -P '.{0,3}%' | sed s/.$// | tr -d ' ')
+    curVol=$(pacmd list-sinks | grep -A 15 'index: '"$1"'' | grep 'volume:' | grep -E -v 'base volume:' | awk -F : '{print $3; exit}' | grep -o -P '.{0,3}%' | sed s/.$// | tr -d ' ')
 }
 
 


### PR DESCRIPTION
Occasionally, an integer value of 100, in addition of the active volume level, is returned which breaks all conditional statements where an integer expression is expected.

```bash
++ pacmd list-sinks
++ awk '/\* index:/{print $3}'
+ curSink=2
+ getCurVol 2
++ pacmd list-sinks
++ grep -A 15 'index: 2'
++ grep volume:
++ awk -F : '{print $3}'
++ grep -o -P '.{0,3}%'
++ sed 's/.$//'
++ tr -d ' '
++ grep -E -v 'base volume:'
+ curVol='93
100'
+ getIsMuted 2
++ pacmd list-sinks
++ grep -A 15 'index: 2'
++ awk '/muted/{print $2}'
+ isMuted='yes
no'
+ local iconsLen=2
+ '[' 2 -ne 0 ']'
+ local volSplit=75
++ seq 1 2
+ for i in $(seq 1 "$iconsLen")
+ '[' 75 -ge '93
100' ']'
./pulseaudio-control.bash: line 285: [: 93
100: integer expression expected
+ for i in $(seq 1 "$iconsLen")
+ '[' 150 -ge '93
100' ']'
./pulseaudio-control.bash: line 285: [: 93
100: integer expression expected
+ getNickname 2
+ getSinkName 2
++ pactl list sinks short
```