### PR TITLE
Add flags for setting icons, sink names

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,68 +24,16 @@ load-module module-stream-restore restore_device=false
 At a minimum, bash version 4 is required to run the script. You can check your bash version by running `bash --version`.
 
 
-## Configuration
-
-You can change the script configuration at the beginning of the file:
-
-| Name                   |  Values                  | Description |
-| ---------------------- | :----------------------: | ----------- |
-| `OSD`                  | `"yes"` / `"no"`         | Will display an OSD message when changing volume if set to true. |
-| `INC`                  | Numerical                | Sets the increment/decrease that each volume up/down will perform. |
-| `MAX_VOL`              | Numerical                | Maximum volume. |
-| `AUTOSYNC`             | `"yes"` / `"no"`         | Will automatically sync all program volumes with the volume of your current sink (output) whenever you change the volume. This is useful if you manage multiple outputs and have issues with the app volumes becoming out of sync with the output. |
-| `VOLUME_ICONS`         | Bash array with i        cons like `( "🔉" "🔊" )`\* | Icons used for the volume, ordered by sound level. The volume levels are divided by the number of icons inside it. For example, if you are using 4 icons and `MAX_VOL` is 100, they will show up in order when the volume is lower than 25, 50, 75 and 100. This is useful because some fonts only have 2 volume icons, while others can have up to 4. |
-| `MUTED_ICON`           | String\*                 | Icon used for the muted volume. |
-| `MUTED_COLOR`          | String ([polybar color](https://github.com/polybar/polybar/wiki/Formatting#foreground-color-f))   | Color used when the audio is muted. |
-| `NOTIFICATIONS`        | `"yes"` / `"no"`         | Sends a notification when the sink is changed. |
-| `SINK_ICON`            | String\*                 | Icon always displayed to the left of the sink names. |
-| `SINK_BLACKLIST`       | Bash array               | A blacklist for whenever sinks are switched. Use `pactl list sinks short` to see all active sink names. |
-| `SINK_NICKNAMES`       | Bash associative array   | Maps the PulseAudio sink names to human-readable nicknames. Use `pactl list sinks short` to obtain the active sinks names. If unconfigured, `Sink #N` is used instead. Custom icons\* for the sinks can be added here if `SINK_ICON` is set to `""`. |
-| `SINK_NICKNAME_PROP`   | String                   | Property (see `pacmd list-sinks`) to use for sink nicknames, where not explicitly set in `SINK_NICKNAMES`. |
-
-\*Check the [Useful icons](#useful-icons) section for examples.
-
-Alternatively, these can be set via command-line arguments, such as:
-```ini
-[module/pulseaudio-control]
-type = custom/script
-exec = "polybar-pulseaudio-control --vol-max=150 --vol-icons='🔈 ,🔉 ,🔊 ' --sink-name-from-prop=device.description --osd"
-```
-
-refer to `polybar-pulseaudio-control help` for a full listing of the available options and their defaults.
-
-
-## Module
-
-The example from the screenshot can:
-
-* Raise and decrease the volume on mousewheel scroll
-* Mute the audio on left click
-* Switch between devices on mousewheel click
-* Open `pavucontrol` on right click
-
-```ini
-[module/pulseaudio-control]
-type = custom/script
-tail = true
-label=%output%
-format-underline = ${colors.blue}
-
-exec = ~/.config/polybar/scripts/pulseaudio-control.bash listen
-click-right = exec pavucontrol &
-click-left = ~/.config/polybar/scripts/pulseaudio-control.bash togmute
-click-middle = ~/.config/polybar/scripts/pulseaudio-control.bash next-sink
-scroll-up = ~/.config/polybar/scripts/pulseaudio-control.bash up
-scroll-down = ~/.config/polybar/scripts/pulseaudio-control.bash down
-label-padding = 2
-label-foreground = ${colors.foreground}
-```
-
-*Note that you will have to change the paths above to where your script is saved. You might want to change or remove the colors and labels, too.*
-
 ## Usage
 
-Here are all the available actions, in case you want to modify the module above, or want to use it for different reasons:
+`polybar-pulseaudio-control` is expected to be invoked from a [polybar](//github.com/polybar/polybar) module:
+```ini
+[module/pulseaudio-control]
+type = custom/script
+exec = polybar-pulseaudio-control [option...] <action>
+```
+
+where `action`, and (optionally) `option`s are as specified in `polybar-pulseaudio-control help`:
 
 ```
 Options: (defaults)
@@ -115,16 +63,47 @@ Actions:
                       the be the same as the current sink's volume
 ```
 
+See the [Module](#module) section for a concrete example, or the [Useful icons](#useful-icons) section for example icons.
+
+
+## Module
+
+The example from the screenshot can:
+
+* Raise and decrease the volume on mousewheel scroll
+* Mute the audio on left click
+* Switch between devices on mousewheel click
+* Open `pavucontrol` on right click
+
+```ini
+[module/pulseaudio-control]
+type = custom/script
+tail = true
+label=%output%
+format-underline = ${colors.blue}
+
+exec = "~/.config/polybar/scripts/pulseaudio-control.bash --vol-max=150 --vol-icons='🔈 ,🔉 ,🔊 ' --sink-name-from-prop=device.description --osd listen"
+click-right = exec pavucontrol &
+click-left = ~/.config/polybar/scripts/pulseaudio-control.bash togmute
+click-middle = ~/.config/polybar/scripts/pulseaudio-control.bash next-sink
+scroll-up = ~/.config/polybar/scripts/pulseaudio-control.bash up
+scroll-down = ~/.config/polybar/scripts/pulseaudio-control.bash down
+label-padding = 2
+label-foreground = ${colors.foreground}
+```
+
+*Note that you will have to change the paths above to where your script is saved. You might want to change or remove the colors and labels, too.*
+
 ## Useful icons
 
 Here's a list with some icons from different fonts you can copy-paste. Most have an space afterwards so that the module has a bit of spacing. They may appear bugged on your browser if the font isn't available there. Please add yours if they aren't in the list.
 
 | Font name                                       | Volumes               | Muted   | Sink icons             |
 | ----------------------------------------------- | :-------------------: | :-----: | :--------------------: |
-| [FontAwesome](https://fontawesome.com)          | `(" " " ")`         | `" "`  | `" "`, `" "`         |
-| [Material](https://material.io/resources/icons) | `(" " " " " ")`    | `" "`  | `" "`, `" "`, `" "` |
-| Emoji                                           | `("🔈 " "🔉 " "🔊 ")` | `"🔇 "` | `"🔈 "`, `"🎧"`        |
-| Emoji v2                                        | `("🕨 " "🕩 " "🕪 ")`    | `"🔇 "` | `"🕨 "`, `"🎧"`         |
+| [FontAwesome](https://fontawesome.com)          | `" , "`         | `" "`  | `" "` or `" "`         |
+| [Material](https://material.io/resources/icons) | `" , , "`    | `" "`  | `" "` or `" "` or `" "` |
+| Emoji                                           | `"🔈 ,🔉 ,🔊 "` | `"🔇 "` | `"🔈 "` or `"🎧"`        |
+| Emoji v2                                        | `"🕨 ,🕩 ,🕪 "`    | `"🔇 "` | `"🕨 "` or `"🎧"`         |
 
 Most of these can be used after downloading a [Nerd Font](https://www.nerdfonts.com/), or from your distro's repository.
 

--- a/README.md
+++ b/README.md
@@ -44,6 +44,15 @@ You can change the script configuration at the beginning of the file:
 
 \*Check the [Useful icons](#useful-icons) section for examples.
 
+Alternatively, these can be set via command-line arguments, such as:
+```ini
+[module/pulseaudio-control]
+type = custom/script
+exec = "polybar-pulseaudio-control --vol-max=150 --vol-icons='🔈 ,🔉 ,🔊 ' --sink-name-from-prop=device.description --osd"
+```
+
+refer to `polybar-pulseaudio-control help` for a full listing of the available options and their defaults.
+
 
 ## Module
 

--- a/README.md
+++ b/README.md
@@ -37,18 +37,18 @@ where `action`, and (optionally) `option`s are as specified in `polybar-pulseaud
 
 ```
 Options: (defaults)
-    --autosync, --no-autosync             whether to maintain same volume for all programs (no)
+    --autosync | --no-autosync            whether to maintain same volume for all programs (no)
     --color-mute <rrggbb>                 color in which to format when muted (6b6b6b)
-    --notifications, --no-notifications   whether to show notifications when changing sink (no)
-    --osd, --no-osd                       whether to display KDE's OSD message (no)
-    --icon-muted <icon>                   icon to use when muted (# )
-    --icon-sink <icon>                    icon to use for sink (# )
-    --icons-volume <icon>[,<icon>...]     icons for volume, from lower to higher (# ,# ,# )
+    --notifications | --no-notifications  whether to show notifications when changing sink (no)
+    --osd | --no-osd                      whether to display KDE's OSD message (no)
+    --icon-muted <icon>                   icon to use when muted (none)
+    --icon-sink <icon>                    icon to use for sink (none)
+    --icons-volume <icon>[,<icon>...]     icons for volume, from lower to higher (none)
     --volume-max <int>                    maximum volume to which to allow increasing (130)
     --volume-step <int>                   step size when inc/decrementing volume (2)
-    --sink-blacklist <name>[,<name>...]   sinks to ignore when switching ()
-    --sink-nickname-from <prop>           pacmd property to use for sink name ()
-    --sink-nickname <name>:<nick>         nickname to assign to given sink name (may be given multiple times) ()
+    --sink-blacklist <name>[,<name>...]   sinks to ignore when switching (none)
+    --sink-nickname-from <prop>           pacmd property to use for sink name (none)
+    --sink-nickname <name>:<nick>         nickname to assign to given sink name (may be given multiple times) (none)
 
 Actions:
     help              display this help and exit

--- a/README.md
+++ b/README.md
@@ -41,6 +41,7 @@ You can change the script configuration at the beginning of the file:
 | `SINK_ICON`            | String\*                 | Icon always displayed to the left of the sink names. |
 | `SINK_BLACKLIST`       | Bash array               | A blacklist for whenever sinks are switched. Use `pactl list sinks short` to see all active sink names. |
 | `SINK_NICKNAMES`       | Bash associative array   | Maps the PulseAudio sink names to human-readable nicknames. Use `pactl list sinks short` to obtain the active sinks names. If unconfigured, `Sink #N` is used instead. Custom icons\* for the sinks can be added here if `SINK_ICON` is set to `""`. |
+| `SINK_NICKNAME_PROP`   | String                   | Property (see `pacmd list-sinks`) to use for sink nicknames, where not explicitly set in `SINK_NICKNAMES`. |
 
 \*Check the [Useful icons](#useful-icons) section for examples.
 

--- a/README.md
+++ b/README.md
@@ -38,48 +38,48 @@ where `action`, and (optionally) `option`s are as specified in `polybar-pulseaud
 ```
 Usage: ./pulseaudio-control.bash [OPTION...] ACTION
 
-Options: (defaults)
-    --autosync | --no-autosync            whether to maintain same volume for
-                                          all programs (no)
-    --color-muted <rrggbb>                color in which to format when muted
-                                          (6b6b6b)
-    --notifications | --no-notifications  whether to show notifications when
-                                          changing sinks (no)
-    --osd | --no-osd                      whether to display KDE's OSD message
-                                          (no)
-    --icon-muted <icon>                   icon to use when muted (none)
-    --icon-sink <icon>                    icon to use for sink (none)
-    --icons-volume <icon>[,<icon>...]     icons for volume, from lower to higher
-                                          (none)
-    --volume-max <int>                    maximum volume to which to allow
-                                          increasing (130)
-    --volume-step <int>                   step size when inc/decrementing volume
-                                          (2)
-    --sink-blacklist <name>[,<name>...]   sinks to ignore when switching (none)
-    --sink-nicknames-from <prop>          pacmd property to use for sink names,
-                                          unless overriden by --sink-nickname.
-                                          Its possible values are listed under
-                                          the 'properties' key in the output
-                                          of `pacmd list-sinks` (none)
-    --sink-nickname <name>:<nick>         nickname to assign to given sink name,
-                                          taking priority over
-                                          --sink-nicknames-from. May be given
-                                          multiple times, and 'name' is exactly
-                                          as listed in the output of
-                                          `pactl list sinks short | cut -f2`
-                                          (none)
+Options: [defaults]
+  --autosync | --no-autosync            whether to maintain same volume for all
+                                        programs [no]
+  --color-muted <rrggbb>                color in which to format when muted
+                                        [6b6b6b]
+  --notifications | --no-notifications  whether to show notifications when
+                                        changing sinks [no]
+  --osd | --no-osd                      whether to display KDE's OSD message
+                                        [no]
+  --icon-muted <icon>                   icon to use when muted [none]
+  --icon-sink <icon>                    icon to use for sink [none]
+  --icons-volume <icon>[,<icon>...]     icons for volume, from lower to higher
+                                        [none]
+  --volume-max <int>                    maximum volume to which to allow
+                                        increasing [130]
+  --volume-step <int>                   step size when inc/decrementing volume
+                                        [2]
+  --sink-blacklist <name>[,<name>...]   sinks to ignore when switching [none]
+  --sink-nicknames-from <prop>          pacmd property to use for sink names,
+                                        unless overriden by --sink-nickname.
+                                        Its possible values are listed under
+                                        the 'properties' key in the output of
+                                        `pacmd list-sinks` [none]
+  --sink-nickname <name>:<nick>         nickname to assign to given sink name,
+                                        taking priority over
+                                        --sink-nicknames-from. May be given
+                                        multiple times, and 'name' is exactly as
+                                        listed in the output of
+                                        `pactl list sinks short | cut -f2`
+                                        [none]
 
 Actions:
-    help              display this help and exit
-    output            print the PulseAudio status once
-    listen            listen for changes in PulseAudio to automatically
-                      update this script's output
-    up, down          increase or decrease the default sink's volume
-    mute, unmute      mute or unmute the default sink's audio
-    togmute           switch between muted and unmuted
-    next-sink         switch to the next available sink
-    sync              synchronize all the output streams volume to
-                      be the same as the current sink's volume
+  help              display this help and exit
+  output            print the PulseAudio status once
+  listen            listen for changes in PulseAudio to automatically update
+                    this script's output
+  up, down          increase or decrease the default sink's volume
+  mute, unmute      mute or unmute the default sink's audio
+  togmute           switch between muted and unmuted
+  next-sink         switch to the next available sink
+  sync              synchronize all the output streams volume to be the same
+                    as the current sink's volume
 ```
 
 See the [Module](#module) section for an example, or the [Useful icons](#useful-icons) section for some packs of icons.

--- a/README.md
+++ b/README.md
@@ -36,9 +36,11 @@ exec = polybar-pulseaudio-control [option...] <action>
 where `action`, and (optionally) `option`s are as specified in `polybar-pulseaudio-control help`:
 
 ```
+Usage: ./pulseaudio-control.bash [OPTION...] ACTION
+
 Options: (defaults)
     --autosync | --no-autosync            whether to maintain same volume for all programs (no)
-    --color-mute <rrggbb>                 color in which to format when muted (6b6b6b)
+    --color-muted <rrggbb>                color in which to format when muted (6b6b6b)
     --notifications | --no-notifications  whether to show notifications when changing sink (no)
     --osd | --no-osd                      whether to display KDE's OSD message (no)
     --icon-muted <icon>                   icon to use when muted (none)
@@ -47,10 +49,11 @@ Options: (defaults)
     --volume-max <int>                    maximum volume to which to allow increasing (130)
     --volume-step <int>                   step size when inc/decrementing volume (2)
     --sink-blacklist <name>[,<name>...]   sinks to ignore when switching (none)
-    --sink-nickname-from <prop>           pacmd property to use for sink name (none)
+    --sink-nicknames-from <prop>          pacmd property to use for sink names (none)
                                           as listed under the 'properties' key in the output of `pacmd list-sinks`
-    --sink-nickname <name>:<nick>         nickname to assign to given sink name (may be given multiple times) (none)
+    --sink-nickname <name>:<nick>         nickname to assign to given sink name, may be given multiple times (none)
                                           where 'name' is exactly as listed in the output of `pactl list sinks short | cut -f2`
+                                          and with more priority than --sink-nicknames-from
 
 Actions:
     help              display this help and exit
@@ -62,10 +65,10 @@ Actions:
     togmute           switch between muted and unmuted
     next-sink         switch to the next available sink
     sync              synchronize all the output streams volume to
-                      the be the same as the current sink's volume
+                      be the same as the current sink's volume
 ```
 
-See the [Module](#module) section for a concrete example, or the [Useful icons](#useful-icons) section for example icons.
+See the [Module](#module) section for an example, or the [Useful icons](#useful-icons) section for some packs of icons.
 
 
 ## Module
@@ -81,17 +84,17 @@ The example from the screenshot can:
 [module/pulseaudio-control]
 type = custom/script
 tail = true
-label=%output%
-format-underline = ${colors.blue}
+format-underline = ${colors.cyan}
+label-padding = 2
+label-foreground = ${colors.foreground}
 
-exec = "~/.config/polybar/scripts/pulseaudio-control.bash --volume-max=150 --icons-volume='🔈 ,🔉 ,🔊 ' --sink-nickname-from-prop=device.description --osd listen"
+# Icons mixed from Font Awesome 5 and Material Icons
+exec = ~/.config/polybar/scripts/pulseaudio-control.bash --volume-max 130 --icons-volume " , " --icon-muted " " --sink-blacklist "alsa_output.pci-0000_01_00.1.hdmi-stereo-extra2" --sink-nicknames-from "device.description" --sink-nickname "alsa_output.pci-0000_00_1f.3.analog-stereo:  Speakers" --sink-nickname "alsa_output.usb-Kingston_HyperX_Virtual_Surround_Sound_00000000-00.analog-stereo:  Headphones" listen
 click-right = exec pavucontrol &
 click-left = ~/.config/polybar/scripts/pulseaudio-control.bash togmute
 click-middle = ~/.config/polybar/scripts/pulseaudio-control.bash next-sink
 scroll-up = ~/.config/polybar/scripts/pulseaudio-control.bash up
 scroll-down = ~/.config/polybar/scripts/pulseaudio-control.bash down
-label-padding = 2
-label-foreground = ${colors.foreground}
 ```
 
 *Note that you will have to change the paths above to where your script is saved. You might want to change or remove the colors and labels, too.*
@@ -100,16 +103,22 @@ label-foreground = ${colors.foreground}
 
 Here's a list with some icons from different fonts you can copy-paste. Most have an space afterwards so that the module has a bit of spacing. They may appear bugged on your browser if the font isn't available there. Please add yours if they aren't in the list.
 
-| Font name                                       | Volumes               | Muted   | Sink icons             |
-| ----------------------------------------------- | :-------------------: | :-----: | :--------------------: |
-| [FontAwesome](https://fontawesome.com)          | `" , "`         | `" "`  | `" "` or `" "`         |
+| Font name                                       | Volumes         | Muted   | Sink icons                 |
+| ----------------------------------------------- | :-------------: | :-----: | :------------------------: |
+| [FontAwesome](https://fontawesome.com)          | `" , "`       | `" "`  | `" "` or `" "`           |
 | [Material](https://material.io/resources/icons) | `" , , "`    | `" "`  | `" "` or `" "` or `" "` |
-| Emoji                                           | `"🔈 ,🔉 ,🔊 "` | `"🔇 "` | `"🔈 "` or `"🎧"`        |
-| Emoji v2                                        | `"🕨 ,🕩 ,🕪 "`    | `"🔇 "` | `"🕨 "` or `"🎧"`         |
+| Emoji                                           | `"🔈 ,🔉 ,🔊 "` | `"🔇 "` | `"🔈 "` or `"🎧 "`         |
+| Emoji v2                                        | `"🕨 ,🕩 ,🕪 "`    | `"🔇 "` | `"🕨 "` or `"🎧 "`          |
 
-Most of these can be used after downloading a [Nerd Font](https://www.nerdfonts.com/), or from your distro's repository.
+Most of these can be used after downloading a [Nerd Font](https://www.nerdfonts.com/) and including it in your Polybar config. For example:
 
-##  Sources
+```ini
+font-X = Font Awesome 5 Free: style=Solid: pixelsize=11
+font-Y = Font Awesome 5 Brands: pixelsize=11
+font-Z = Material Icons: style=Regular: pixelsize=13; 2
+```
+
+## Sources
 
 Part of the script and of this README's info was taken from [customlinux.blogspot.com](http://customlinux.blogspot.com/2013/02/pavolumesh-control-active-sink-volume.html), the creator. It was later adapted to fit polybar. It is also mixed with [the ArcoLinux version](https://github.com/arcolinux/arcolinux-polybar/blob/master/etc/skel/.config/polybar/scripts/pavolume.sh), which implemented the `listen` action to use less resources.
 

--- a/README.md
+++ b/README.md
@@ -39,21 +39,35 @@ where `action`, and (optionally) `option`s are as specified in `polybar-pulseaud
 Usage: ./pulseaudio-control.bash [OPTION...] ACTION
 
 Options: (defaults)
-    --autosync | --no-autosync            whether to maintain same volume for all programs (no)
-    --color-muted <rrggbb>                color in which to format when muted (6b6b6b)
-    --notifications | --no-notifications  whether to show notifications when changing sink (no)
-    --osd | --no-osd                      whether to display KDE's OSD message (no)
+    --autosync | --no-autosync            whether to maintain same volume for
+                                          all programs (no)
+    --color-muted <rrggbb>                color in which to format when muted
+                                          (6b6b6b)
+    --notifications | --no-notifications  whether to show notifications when
+                                          changing sinks (no)
+    --osd | --no-osd                      whether to display KDE's OSD message
+                                          (no)
     --icon-muted <icon>                   icon to use when muted (none)
     --icon-sink <icon>                    icon to use for sink (none)
-    --icons-volume <icon>[,<icon>...]     icons for volume, from lower to higher (none)
-    --volume-max <int>                    maximum volume to which to allow increasing (130)
-    --volume-step <int>                   step size when inc/decrementing volume (2)
+    --icons-volume <icon>[,<icon>...]     icons for volume, from lower to higher
+                                          (none)
+    --volume-max <int>                    maximum volume to which to allow
+                                          increasing (130)
+    --volume-step <int>                   step size when inc/decrementing volume
+                                          (2)
     --sink-blacklist <name>[,<name>...]   sinks to ignore when switching (none)
-    --sink-nicknames-from <prop>          pacmd property to use for sink names (none)
-                                          as listed under the 'properties' key in the output of `pacmd list-sinks`
-    --sink-nickname <name>:<nick>         nickname to assign to given sink name, may be given multiple times (none)
-                                          where 'name' is exactly as listed in the output of `pactl list sinks short | cut -f2`
-                                          and with more priority than --sink-nicknames-from
+    --sink-nicknames-from <prop>          pacmd property to use for sink names,
+                                          unless overriden by --sink-nickname.
+                                          Its possible values are listed under
+                                          the 'properties' key in the output
+                                          of `pacmd list-sinks` (none)
+    --sink-nickname <name>:<nick>         nickname to assign to given sink name,
+                                          taking priority over
+                                          --sink-nicknames-from. May be given
+                                          multiple times, and 'name' is exactly
+                                          as listed in the output of
+                                          `pactl list sinks short | cut -f2`
+                                          (none)
 
 Actions:
     help              display this help and exit

--- a/README.md
+++ b/README.md
@@ -87,7 +87,19 @@ label-foreground = ${colors.foreground}
 Here are all the available actions, in case you want to modify the module above, or want to use it for different reasons:
 
 ```
-Usage: pulseaudio-control.bash ACTION
+Options: (defaults)
+    --autosync, --no-autosync             whether to maintain same volume for all programs (no)
+    --color-mute <rrggbb>                 color in which to format when muted (6b6b6b)
+    --notifications, --no-notifications   whether to show notifications when changing sink (no)
+    --osd, --no-osd                       whether to display KDE's OSD message (no)
+    --vol-icons <icon>[,<icon>...]        icons for volume, from lower to higher (# ,# ,# )
+    --vol-icon-mute <icon>                icon to use when muted (# )
+    --vol-max <int>                       maximum volume to which to allow increasing (130)
+    --vol-step <int>                      step size when inc/decrementing volume (2)
+    --sink-blacklist <name>[,<name>...]   sinks to ignore when switching ()
+    --sink-icon <icon>                    icon to use for sink (# )
+    --sink-name-from <prop>               pacmd property to use for sink name ()
+    --sink-nickname <name>:<nick>         nickname to assign to given sink name (may be given multiple times) ()
 
 Actions:
     help              display this help and exit

--- a/README.md
+++ b/README.md
@@ -48,7 +48,9 @@ Options: (defaults)
     --volume-step <int>                   step size when inc/decrementing volume (2)
     --sink-blacklist <name>[,<name>...]   sinks to ignore when switching (none)
     --sink-nickname-from <prop>           pacmd property to use for sink name (none)
+                                          as listed under the 'properties' key in the output of `pacmd list-sinks`
     --sink-nickname <name>:<nick>         nickname to assign to given sink name (may be given multiple times) (none)
+                                          where 'name' is exactly as listed in the output of `pactl list sinks short | cut -f2`
 
 Actions:
     help              display this help and exit

--- a/README.md
+++ b/README.md
@@ -41,13 +41,13 @@ Options: (defaults)
     --color-mute <rrggbb>                 color in which to format when muted (6b6b6b)
     --notifications, --no-notifications   whether to show notifications when changing sink (no)
     --osd, --no-osd                       whether to display KDE's OSD message (no)
-    --vol-icons <icon>[,<icon>...]        icons for volume, from lower to higher (# ,# ,# )
-    --vol-icon-mute <icon>                icon to use when muted (# )
-    --vol-max <int>                       maximum volume to which to allow increasing (130)
-    --vol-step <int>                      step size when inc/decrementing volume (2)
+    --icon-muted <icon>                   icon to use when muted (# )
+    --icon-sink <icon>                    icon to use for sink (# )
+    --icons-volume <icon>[,<icon>...]     icons for volume, from lower to higher (# ,# ,# )
+    --volume-max <int>                    maximum volume to which to allow increasing (130)
+    --volume-step <int>                   step size when inc/decrementing volume (2)
     --sink-blacklist <name>[,<name>...]   sinks to ignore when switching ()
-    --sink-icon <icon>                    icon to use for sink (# )
-    --sink-name-from <prop>               pacmd property to use for sink name ()
+    --sink-nickname-from <prop>           pacmd property to use for sink name ()
     --sink-nickname <name>:<nick>         nickname to assign to given sink name (may be given multiple times) ()
 
 Actions:
@@ -82,7 +82,7 @@ tail = true
 label=%output%
 format-underline = ${colors.blue}
 
-exec = "~/.config/polybar/scripts/pulseaudio-control.bash --vol-max=150 --vol-icons='🔈 ,🔉 ,🔊 ' --sink-name-from-prop=device.description --osd listen"
+exec = "~/.config/polybar/scripts/pulseaudio-control.bash --volume-max=150 --icons-volume='🔈 ,🔉 ,🔊 ' --sink-nickname-from-prop=device.description --osd listen"
 click-right = exec pavucontrol &
 click-left = ~/.config/polybar/scripts/pulseaudio-control.bash togmute
 click-middle = ~/.config/polybar/scripts/pulseaudio-control.bash next-sink

--- a/pulseaudio-control.bash
+++ b/pulseaudio-control.bash
@@ -323,12 +323,12 @@ function usage() {
     echo "Usage: $0 [OPTION...] ACTION"
     echo
     echo "Options:"
-    echo "    --vol-icons       icons for volume, from lower to higher (comma-separated)"
-    echo "    --vol-icon-mute   icon to use when muted"
-    echo "    --sink-blacklist  sinks to ignore when switching (comma-separated)"
-    echo "    --sink-icon       icon to use for sink"
-    echo "    --sink-name-from  pacmd property to use for sink name"
-    echo "    --sink-nickname   <name>:<nick> pair to use for sink name (multiple args allowed)"
+    echo "    --vol-icons <icon>[,<icon>...]        icons for volume, from lower to higher"
+    echo "    --vol-icon-mute <icon>                icon to use when muted"
+    echo "    --sink-blacklist <name>[,<name>...]   sinks to ignore when switching"
+    echo "    --sink-icon <icon>                    icon to use for sink"
+    echo "    --sink-name-from <prop>               pacmd property to use for sink name"
+    echo "    --sink-nickname <name>:<nick>         nickname to assign to given sink name (may be given multiple times)"
     echo
     echo "Actions:"
     echo "    help              display this help and exit"

--- a/pulseaudio-control.bash
+++ b/pulseaudio-control.bash
@@ -320,7 +320,7 @@ function output() {
 
 
 function usage() {
-    echo "Usage: $0 ACTION"
+    echo "Usage: $0 [OPTION...] ACTION"
     echo
     echo "Options:"
     echo "    --vol-icon-low    icon to use at low volume"

--- a/pulseaudio-control.bash
+++ b/pulseaudio-control.bash
@@ -347,22 +347,31 @@ function usage() {
 }
 
 while [[ "$1" = --* ]]; do
-    case "$1" in
-        --vol-icons=*)
-            IFS=, read -r -a VOLUME_ICONS <<< "${1#--vol-icons=}"
+    if [[ "$1" = *=* ]]; then
+        arg="${1//=*/}"
+        val="${1//*=/}"
+        shift
+    else
+        arg="$1"
+        val="$2"
+        shift; shift
+    fi
+
+    case "$arg" in
+        --vol-icons)
+            IFS=, read -r -a VOLUME_ICONS <<< "$val"
             ;;
-        --sink-icon=*)
-            SINK_ICON="${1#--sink-icon=}"
+        --sink-icon)
+            SINK_ICON="$val"
             ;;
-        --sink-name-from=*)
-            setNicknames "${1#--sink-name-from=}"
+        --sink-name-from)
+            setNicknames "$val"
             ;;
         *)
-            echo "Unrecognised option: $1" >&2
+            echo "Unrecognised option: $arg" >&2
             exit 1
             ;;
     esac
-    shift
 done
 
 case "$1" in

--- a/pulseaudio-control.bash
+++ b/pulseaudio-control.bash
@@ -366,7 +366,7 @@ while [[ "$1" = --* ]]; do
             setNicknames "${1#--sink-name-from=}"
             ;;
         *)
-            >&2 echo "Unrecognised option: $1"
+            echo "Unrecognised option: $1" >&2
             exit 1
             ;;
     esac
@@ -405,7 +405,7 @@ case "$1" in
         usage
         ;;
     *)
-        >&2 "Unrecognised action: $1"
+        echo "Unrecognised action: $1" >&2
         exit 1
         ;;
 esac

--- a/pulseaudio-control.bash
+++ b/pulseaudio-control.bash
@@ -335,13 +335,19 @@ function output() {
 function usage() {
     echo "Usage: $0 [OPTION...] ACTION"
     echo
-    echo "Options:"
-    echo "    --vol-icons <icon>[,<icon>...]        icons for volume, from lower to higher"
-    echo "    --vol-icon-mute <icon>                icon to use when muted"
-    echo "    --sink-blacklist <name>[,<name>...]   sinks to ignore when switching"
-    echo "    --sink-icon <icon>                    icon to use for sink"
-    echo "    --sink-name-from <prop>               pacmd property to use for sink name"
-    echo "    --sink-nickname <name>:<nick>         nickname to assign to given sink name (may be given multiple times)"
+    echo "Options: (defaults)"
+    echo "    --autosync, --no-autosync             whether to maintain same volume for all programs ($AUTOSYNC)"
+    echo "    --color-mute <rrggbb>                 color in which to format when muted (${MUTED_COLOR:4:-1})"
+    echo "    --notifications, --no-notifications   whether to show notifications when changing sink ($NOTIFICATIONS)"
+    echo "    --osd, --no-osd                       whether to display KDE's OSD message ($OSD)"
+    echo "    --vol-icons <icon>[,<icon>...]        icons for volume, from lower to higher ($(IFS=, ; echo "${VOLUME_ICONS[*]}"))"
+    echo "    --vol-icon-mute <icon>                icon to use when muted ($MUTED_ICON)"
+    echo "    --vol-max <int>                       maximum volume to which to allow increasing ($MAX_VOL)"
+    echo "    --vol-step <int>                      step size when inc/decrementing volume ($INC)"
+    echo "    --sink-blacklist <name>[,<name>...]   sinks to ignore when switching ()"
+    echo "    --sink-icon <icon>                    icon to use for sink ($SINK_ICON)"
+    echo "    --sink-name-from <prop>               pacmd property to use for sink name ($SINK_NICKNAME_PROP)"
+    echo "    --sink-nickname <name>:<nick>         nickname to assign to given sink name (may be given multiple times) ()"
     echo
     echo "Actions:"
     echo "    help              display this help and exit"
@@ -379,8 +385,38 @@ while [[ "$1" = --* ]]; do
     fi
 
     case "$arg" in
+        --autosync)
+            AUTOSYNC=yes
+            ;;
+        --no-autosync)
+            AUTOSYNC=no
+            ;;
+        --color-mute|--colour-mute)
+            MUTED_COLOR="$val"
+            ;;
+        --notifications)
+            NOTIFICATIONS=yes
+            ;;
+        --no-notifications)
+            NOTIFICATIONS=no
+            ;;
+        --osd)
+            OSD=yes
+            ;;
+        --no-osd)
+            OSD=no
+            ;;
         --vol-icons)
             IFS=, read -r -a VOLUME_ICONS <<< "$val"
+            ;;
+        --vol-icon-mute)
+            MUTED_ICON="$val"
+            ;;
+        --vol-max)
+            MAX_VOL="$val"
+            ;;
+        --vol-step)
+            INC="$val"
             ;;
         --sink-blacklist)
             IFS=, read -r -a SINK_BLACKLIST <<< "$val"

--- a/pulseaudio-control.bash
+++ b/pulseaudio-control.bash
@@ -66,7 +66,7 @@ function getNickname() {
     if [ -n "${SINK_NICKNAMES[$sinkName]}" ]; then
         nickname="${SINK_NICKNAMES[$sinkName]}"
     elif [ -n "$SINK_NICKNAME_PROP" ]; then
-        nickname="$(getNicknameFromProp "$SINK_NICKNAME_PROP" "$sinkName")"
+        getNicknameFromProp "$SINK_NICKNAME_PROP" "$sinkName"
         # Cache that result for next time
         SINK_NICKNAMES["$sinkName"]="$nickname"
     fi
@@ -81,6 +81,7 @@ function getNicknameFromProp() {
     local nickname_prop="$1"
     local for_name="$2"
 
+    nickname=
     while read -r property value; do
         case "$property" in
             name:)
@@ -91,7 +92,7 @@ function getNicknameFromProp() {
                 if [ "$sink_name" != "$for_name" ]; then
                     continue
                 fi
-                echo "${value:3:-1}"
+                nickname="${value:3:-1}"
                 break
                 ;;
         esac

--- a/pulseaudio-control.bash
+++ b/pulseaudio-control.bash
@@ -81,23 +81,21 @@ function getNicknameFromProp() {
     local nickname_prop="$1"
     local for_name="$2"
 
-    mapfile -t lines < <(pacmd list-sinks)
-    for line in "${lines[@]}"; do
-        case "$line" in
-            *name:*)
-                sink_name="$(echo "$line" | sed -E 's/.*name: <(.*)>/\1/')"
+    while read -r property value; do
+        case "$property" in
+            name:)
+                sink_name="${value//[<>]/}"
                 unset sink_desc
                 ;;
-            *"$nickname_prop ="*)
+            "$nickname_prop")
                 if [ "$sink_name" != "$for_name" ]; then
                     continue
                 fi
-                prop_value="$(echo "$line" | sed -E "s/.*$nickname_prop = \"(.*)\"/\1/")"
-                echo "$prop_value"
+                echo "${value:3:-1}"
                 break
                 ;;
         esac
-    done
+    done < <(pacmd list-sinks)
 }
 
 # Saves the status of the sink passed by parameter into a variable named

--- a/pulseaudio-control.bash
+++ b/pulseaudio-control.bash
@@ -13,7 +13,7 @@ ICON_SINK=
 NOTIFICATIONS="no"
 OSD="no"
 SINK_NICKNAMES_PROP=
-VOLUME_INC=2
+VOLUME_STEP=2
 VOLUME_MAX=130
 declare -A SINK_NICKNAMES
 declare -a ICONS_VOLUME
@@ -110,7 +110,7 @@ function volUp() {
         return 1
     fi
     getCurVol "$curSink"
-    local maxLimit=$((VOLUME_MAX - VOLUME_INC))
+    local maxLimit=$((VOLUME_MAX - VOLUME_STEP))
 
     # Checking the volume upper bounds so that if VOLUME_MAX was 100% and the
     # increase percentage was 3%, a 99% volume would top at 100% instead
@@ -118,7 +118,7 @@ function volUp() {
     if [ "$curVol" -le "$VOLUME_MAX" ] && [ "$curVol" -ge "$maxLimit" ]; then
         pactl set-sink-volume "$curSink" "$VOLUME_MAX%"
     elif [ "$curVol" -lt "$maxLimit" ]; then
-        pactl set-sink-volume "$curSink" "+$VOLUME_INC%"
+        pactl set-sink-volume "$curSink" "+$VOLUME_STEP%"
     fi
 
     if [ $OSD = "yes" ]; then showOSD "$curSink"; fi
@@ -133,7 +133,7 @@ function volDown() {
         echo "PulseAudio not running"
         return 1
     fi
-    pactl set-sink-volume "$curSink" "-$VOLUME_INC%"
+    pactl set-sink-volume "$curSink" "-$VOLUME_STEP%"
 
     if [ $OSD = "yes" ]; then showOSD "$curSink"; fi
     if [ $AUTOSYNC = "yes" ]; then volSync; fi
@@ -342,7 +342,7 @@ Options: [defaults]
   --volume-max <int>                    maximum volume to which to allow
                                         increasing [$VOLUME_MAX]
   --volume-step <int>                   step size when inc/decrementing volume
-                                        [$VOLUME_INC]
+                                        [$VOLUME_STEP]
   --sink-blacklist <name>[,<name>...]   sinks to ignore when switching [none]
   --sink-nicknames-from <prop>          pacmd property to use for sink names,
                                         unless overriden by --sink-nickname.
@@ -427,7 +427,7 @@ while [[ "$1" = --* ]]; do
             VOLUME_MAX="$val"
             ;;
         --volume-step)
-            VOLUME_INC="$val"
+            VOLUME_STEP="$val"
             ;;
         --sink-blacklist)
             IFS=, read -r -a SINK_BLACKLIST <<< "$val"

--- a/pulseaudio-control.bash
+++ b/pulseaudio-control.bash
@@ -5,29 +5,23 @@
 # https://github.com/marioortizmanero/polybar-pulseaudio-control #
 ##################################################################
 
-# Script configuration (more info in the README)
-OSD="no"  # On Screen Display message for KDE if enabled
-INC=2  # Increment when lowering/rising the volume
-MAX_VOL=130  # Maximum volume
-AUTOSYNC="no"  # All programs have the same volume if enabled
-VOLUME_ICONS=( "# " "# " "# " )  # Volume icons array, from lower volume to higher
-MUTED_ICON="# "  # Muted volume icon
-MUTED_COLOR="%{F#6b6b6b}"  # Color when the audio is muted
-NOTIFICATIONS="no"  # Notifications when switching sinks if enabled
-SINK_ICON="# "  # Icon always shown to the left of the default sink names
-
-# Blacklist of PulseAudio sink names when switching between them. To obtain
-# the names of your active sinks, use `pactl list sinks short`.
+# Defaults for configurable values, expected to be set by command-line arguments
+OSD="no"
+INC=2
+MAX_VOL=130
+AUTOSYNC="no"
+VOLUME_ICONS=( "# " "# " "# " )
+MUTED_ICON="# "
+MUTED_COLOR="%{F#6b6b6b}"
+NOTIFICATIONS="no"
+SINK_ICON="# "
 SINK_BLACKLIST=(
     "alsa_output.usb-SinkYouDontUse-00.analog-stereo"
 )
-
-# Maps PulseAudio sink names to human-readable names
 declare -A SINK_NICKNAMES
 SINK_NICKNAMES["alsa_output.usb-SomeManufacturer_SomeUsbSoundcard-00.analog-stereo"]="External Soundcard"
-
-# PulseAudio device property for human-readable names where an explicit nickname not given
 SINK_NICKNAME_PROP=
+
 
 # Environment & global constants for the script
 LANGUAGE=en_US  # Some calls depend on English outputs of pactl

--- a/pulseaudio-control.bash
+++ b/pulseaudio-control.bash
@@ -323,41 +323,56 @@ function output() {
 
 
 function usage() {
-    echo "Usage: $0 [OPTION...] ACTION"
-    echo
-    echo "Options: (defaults)"
-    echo "    --autosync | --no-autosync            whether to maintain same volume for all programs ($AUTOSYNC)"
-    echo "    --color-muted <rrggbb>                color in which to format when muted (${COLOR_MUTED:4:-1})"
-    echo "    --notifications | --no-notifications  whether to show notifications when changing sink ($NOTIFICATIONS)"
-    echo "    --osd | --no-osd                      whether to display KDE's OSD message ($OSD)"
-    echo "    --icon-muted <icon>                   icon to use when muted (none)"
-    echo "    --icon-sink <icon>                    icon to use for sink (none)"
-    echo "    --icons-volume <icon>[,<icon>...]     icons for volume, from lower to higher (none)"
-    echo "    --volume-max <int>                    maximum volume to which to allow increasing ($VOLUME_MAX)"
-    echo "    --volume-step <int>                   step size when inc/decrementing volume ($VOLUME_INC)"
-    echo "    --sink-blacklist <name>[,<name>...]   sinks to ignore when switching (none)"
-    echo "    --sink-nicknames-from <prop>          pacmd property to use for sink names (none)"
-    echo "                                          as listed under the 'properties' key in the output of \`pacmd list-sinks\`"
-    echo "    --sink-nickname <name>:<nick>         nickname to assign to given sink name, may be given multiple times (none)"
-    echo "                                          where 'name' is exactly as listed in the output of \`pactl list sinks short | cut -f2\`"
-    echo "                                          and with more priority than --sink-nicknames-from"
-    echo
-    echo "Actions:"
-    echo "    help              display this help and exit"
-    echo "    output            print the PulseAudio status once"
-    echo "    listen            listen for changes in PulseAudio to automatically"
-    echo "                      update this script's output"
-    echo "    up, down          increase or decrease the default sink's volume"
-    echo "    mute, unmute      mute or unmute the default sink's audio"
-    echo "    togmute           switch between muted and unmuted"
-    echo "    next-sink         switch to the next available sink"
-    echo "    sync              synchronize all the output streams volume to"
-    echo "                      be the same as the current sink's volume"
-    echo ""
-    echo "Author:"
-    echo "    Mario Ortiz Manero"
-    echo "More info on GitHub:"
-    echo "    https://github.com/marioortizmanero/polybar-pulseaudio-control"
+    echo "\
+Usage: $0 [OPTION...] ACTION
+
+Options: (defaults)
+    --autosync | --no-autosync            whether to maintain same volume for
+                                          all programs ($AUTOSYNC)
+    --color-muted <rrggbb>                color in which to format when muted
+                                          (${COLOR_MUTED:4:-1})
+    --notifications | --no-notifications  whether to show notifications when
+                                          changing sinks ($NOTIFICATIONS)
+    --osd | --no-osd                      whether to display KDE's OSD message
+                                          ($OSD)
+    --icon-muted <icon>                   icon to use when muted (none)
+    --icon-sink <icon>                    icon to use for sink (none)
+    --icons-volume <icon>[,<icon>...]     icons for volume, from lower to higher
+                                          (none)
+    --volume-max <int>                    maximum volume to which to allow
+                                          increasing ($VOLUME_MAX)
+    --volume-step <int>                   step size when inc/decrementing volume
+                                          ($VOLUME_INC)
+    --sink-blacklist <name>[,<name>...]   sinks to ignore when switching (none)
+    --sink-nicknames-from <prop>          pacmd property to use for sink names,
+                                          unless overriden by --sink-nickname.
+                                          Its possible values are listed under
+                                          the 'properties' key in the output
+                                          of \`pacmd list-sinks\` (none)
+    --sink-nickname <name>:<nick>         nickname to assign to given sink name,
+                                          taking priority over
+                                          --sink-nicknames-from. May be given
+                                          multiple times, and 'name' is exactly
+                                          as listed in the output of
+                                          \`pactl list sinks short | cut -f2\`
+                                          (none)
+
+Actions:
+    help              display this help and exit
+    output            print the PulseAudio status once
+    listen            listen for changes in PulseAudio to automatically update
+                      this script's output
+    up, down          increase or decrease the default sink's volume
+    mute, unmute      mute or unmute the default sink's audio
+    togmute           switch between muted and unmuted
+    next-sink         switch to the next available sink
+    sync              synchronize all the output streams volume to be the same
+                      as the current sink's volume
+
+Author:
+    Mario Ortiz Manero
+More info on GitHub:
+    https://github.com/marioortizmanero/polybar-pulseaudio-control"
 }
 
 while [[ "$1" = --* ]]; do

--- a/pulseaudio-control.bash
+++ b/pulseaudio-control.bash
@@ -339,7 +339,9 @@ function usage() {
     echo "    --volume-step <int>                   step size when inc/decrementing volume ($INC)"
     echo "    --sink-blacklist <name>[,<name>...]   sinks to ignore when switching (none)"
     echo "    --sink-nickname-from <prop>           pacmd property to use for sink name (none)"
+    echo "                                          as listed under the 'properties' key in the output of \`pacmd list-sinks\`"
     echo "    --sink-nickname <name>:<nick>         nickname to assign to given sink name (may be given multiple times) (none)"
+    echo "                                          where 'name' is exactly as listed in the output of \`pactl list sinks short | cut -f2\`"
     echo
     echo "Actions:"
     echo "    help              display this help and exit"

--- a/pulseaudio-control.bash
+++ b/pulseaudio-control.bash
@@ -67,7 +67,7 @@ function getNickname() {
 }
 
 # Sets sink nicknames based on a given property.
-function setNicknames() {
+function setNicknamesFromProp() {
     local nickname_prop="$1"
 
     mapfile -t lines < <(pacmd list-sinks)
@@ -327,6 +327,7 @@ function usage() {
     echo "    --vol-icon-mute   icon to use when muted"
     echo "    --sink-icon       icon to use for sink"
     echo "    --sink-name-from  pacmd property to use for sink name"
+    echo "    --sink-nickname   <name>:<nick> pair to use for sink name (multiple args allowed)"
     echo
     echo "Actions:"
     echo "    help              display this help and exit"
@@ -365,7 +366,10 @@ while [[ "$1" = --* ]]; do
             SINK_ICON="$val"
             ;;
         --sink-name-from)
-            setNicknames "$val"
+            setNicknamesFromProp "$val"
+            ;;
+        --sink-nickname)
+            SINK_NICKNAMES["${val//:*/}"]="${val//*:}"
             ;;
         *)
             echo "Unrecognised option: $arg" >&2

--- a/pulseaudio-control.bash
+++ b/pulseaudio-control.bash
@@ -334,13 +334,13 @@ function usage() {
     echo "    --color-mute <rrggbb>                 color in which to format when muted (${MUTED_COLOR:4:-1})"
     echo "    --notifications, --no-notifications   whether to show notifications when changing sink ($NOTIFICATIONS)"
     echo "    --osd, --no-osd                       whether to display KDE's OSD message ($OSD)"
-    echo "    --vol-icons <icon>[,<icon>...]        icons for volume, from lower to higher ($(IFS=, ; echo "${VOLUME_ICONS[*]}"))"
-    echo "    --vol-icon-mute <icon>                icon to use when muted ($MUTED_ICON)"
-    echo "    --vol-max <int>                       maximum volume to which to allow increasing ($MAX_VOL)"
-    echo "    --vol-step <int>                      step size when inc/decrementing volume ($INC)"
+    echo "    --icon-muted <icon>                   icon to use when muted ($MUTED_ICON)"
+    echo "    --icon-sink <icon>                    icon to use for sink ($SINK_ICON)"
+    echo "    --icons-volume <icon>[,<icon>...]     icons for volume, from lower to higher ($(IFS=, ; echo "${VOLUME_ICONS[*]}"))"
+    echo "    --volume-max <int>                    maximum volume to which to allow increasing ($MAX_VOL)"
+    echo "    --volume-step <int>                   step size when inc/decrementing volume ($INC)"
     echo "    --sink-blacklist <name>[,<name>...]   sinks to ignore when switching ()"
-    echo "    --sink-icon <icon>                    icon to use for sink ($SINK_ICON)"
-    echo "    --sink-name-from <prop>               pacmd property to use for sink name ($SINK_NICKNAME_PROP)"
+    echo "    --sink-nickname-from <prop>           pacmd property to use for sink name ($SINK_NICKNAME_PROP)"
     echo "    --sink-nickname <name>:<nick>         nickname to assign to given sink name (may be given multiple times) ()"
     echo
     echo "Actions:"
@@ -400,25 +400,25 @@ while [[ "$1" = --* ]]; do
         --no-osd)
             OSD=no
             ;;
-        --vol-icons)
-            IFS=, read -r -a VOLUME_ICONS <<< "$val"
-            ;;
-        --vol-icon-mute)
+        --icon-muted)
             MUTED_ICON="$val"
             ;;
-        --vol-max)
+        --icon-sink)
+            SINK_ICON="$val"
+            ;;
+        --icons-volume)
+            IFS=, read -r -a VOLUME_ICONS <<< "$val"
+            ;;
+        --volume-max)
             MAX_VOL="$val"
             ;;
-        --vol-step)
+        --volume-step)
             INC="$val"
             ;;
         --sink-blacklist)
             IFS=, read -r -a SINK_BLACKLIST <<< "$val"
             ;;
-        --sink-icon)
-            SINK_ICON="$val"
-            ;;
-        --sink-name-from)
+        --sink-nickname-from)
             SINK_NICKNAME_PROP="$val"
             ;;
         --sink-nickname)

--- a/pulseaudio-control.bash
+++ b/pulseaudio-control.bash
@@ -206,14 +206,15 @@ function nextSink() {
     pacmd set-default-sink "$newSink"
 
     # Move all audio threads to new sink
-    local inputs=$(pactl list short sink-inputs | cut -f 1)
+    local inputs
+    inputs="$(pactl list short sink-inputs | cut -f 1)"
     for i in $inputs; do
         pacmd move-sink-input "$i" "$newSink"
     done
 
     if [ $NOTIFICATIONS = "yes" ]; then
         getNickname "$newSink"
-        
+
         if command -v dunstify &>/dev/null; then
             notify="dunstify --replace 201839192"
         else

--- a/pulseaudio-control.bash
+++ b/pulseaudio-control.bash
@@ -401,7 +401,11 @@ case "$1" in
     output)
         output
         ;;
-    *)
+    help)
         usage
+        ;;
+    *)
+        >&2 "Unrecognised action: $1"
+        exit 1
         ;;
 esac

--- a/pulseaudio-control.bash
+++ b/pulseaudio-control.bash
@@ -10,16 +10,14 @@ OSD="no"
 INC=2
 MAX_VOL=130
 AUTOSYNC="no"
-VOLUME_ICONS=( "# " "# " "# " )
-MUTED_ICON="# "
+VOLUME_ICONS=( " " )
+MUTED_ICON=" "
 MUTED_COLOR="%{F#6b6b6b}"
 NOTIFICATIONS="no"
-SINK_ICON="# "
+SINK_ICON=" "
 SINK_BLACKLIST=(
-    "alsa_output.usb-SinkYouDontUse-00.analog-stereo"
 )
 declare -A SINK_NICKNAMES
-SINK_NICKNAMES["alsa_output.usb-SomeManufacturer_SomeUsbSoundcard-00.analog-stereo"]="External Soundcard"
 SINK_NICKNAME_PROP=
 
 
@@ -330,18 +328,18 @@ function usage() {
     echo "Usage: $0 [OPTION...] ACTION"
     echo
     echo "Options: (defaults)"
-    echo "    --autosync, --no-autosync             whether to maintain same volume for all programs ($AUTOSYNC)"
+    echo "    --autosync | --no-autosync            whether to maintain same volume for all programs ($AUTOSYNC)"
     echo "    --color-mute <rrggbb>                 color in which to format when muted (${MUTED_COLOR:4:-1})"
-    echo "    --notifications, --no-notifications   whether to show notifications when changing sink ($NOTIFICATIONS)"
-    echo "    --osd, --no-osd                       whether to display KDE's OSD message ($OSD)"
-    echo "    --icon-muted <icon>                   icon to use when muted ($MUTED_ICON)"
-    echo "    --icon-sink <icon>                    icon to use for sink ($SINK_ICON)"
-    echo "    --icons-volume <icon>[,<icon>...]     icons for volume, from lower to higher ($(IFS=, ; echo "${VOLUME_ICONS[*]}"))"
+    echo "    --notifications | --no-notifications  whether to show notifications when changing sink ($NOTIFICATIONS)"
+    echo "    --osd | --no-osd                      whether to display KDE's OSD message ($OSD)"
+    echo "    --icon-muted <icon>                   icon to use when muted (none)"
+    echo "    --icon-sink <icon>                    icon to use for sink (none)"
+    echo "    --icons-volume <icon>[,<icon>...]     icons for volume, from lower to higher (none)"
     echo "    --volume-max <int>                    maximum volume to which to allow increasing ($MAX_VOL)"
     echo "    --volume-step <int>                   step size when inc/decrementing volume ($INC)"
-    echo "    --sink-blacklist <name>[,<name>...]   sinks to ignore when switching ()"
-    echo "    --sink-nickname-from <prop>           pacmd property to use for sink name ($SINK_NICKNAME_PROP)"
-    echo "    --sink-nickname <name>:<nick>         nickname to assign to given sink name (may be given multiple times) ()"
+    echo "    --sink-blacklist <name>[,<name>...]   sinks to ignore when switching (none)"
+    echo "    --sink-nickname-from <prop>           pacmd property to use for sink name (none)"
+    echo "    --sink-nickname <name>:<nick>         nickname to assign to given sink name (may be given multiple times) (none)"
     echo
     echo "Actions:"
     echo "    help              display this help and exit"

--- a/pulseaudio-control.bash
+++ b/pulseaudio-control.bash
@@ -326,48 +326,48 @@ function usage() {
     echo "\
 Usage: $0 [OPTION...] ACTION
 
-Options: (defaults)
-    --autosync | --no-autosync            whether to maintain same volume for
-                                          all programs ($AUTOSYNC)
-    --color-muted <rrggbb>                color in which to format when muted
-                                          (${COLOR_MUTED:4:-1})
-    --notifications | --no-notifications  whether to show notifications when
-                                          changing sinks ($NOTIFICATIONS)
-    --osd | --no-osd                      whether to display KDE's OSD message
-                                          ($OSD)
-    --icon-muted <icon>                   icon to use when muted (none)
-    --icon-sink <icon>                    icon to use for sink (none)
-    --icons-volume <icon>[,<icon>...]     icons for volume, from lower to higher
-                                          (none)
-    --volume-max <int>                    maximum volume to which to allow
-                                          increasing ($VOLUME_MAX)
-    --volume-step <int>                   step size when inc/decrementing volume
-                                          ($VOLUME_INC)
-    --sink-blacklist <name>[,<name>...]   sinks to ignore when switching (none)
-    --sink-nicknames-from <prop>          pacmd property to use for sink names,
-                                          unless overriden by --sink-nickname.
-                                          Its possible values are listed under
-                                          the 'properties' key in the output
-                                          of \`pacmd list-sinks\` (none)
-    --sink-nickname <name>:<nick>         nickname to assign to given sink name,
-                                          taking priority over
-                                          --sink-nicknames-from. May be given
-                                          multiple times, and 'name' is exactly
-                                          as listed in the output of
-                                          \`pactl list sinks short | cut -f2\`
-                                          (none)
+Options: [defaults]
+  --autosync | --no-autosync            whether to maintain same volume for all
+                                        programs [$AUTOSYNC]
+  --color-muted <rrggbb>                color in which to format when muted
+                                        [${COLOR_MUTED:4:-1}]
+  --notifications | --no-notifications  whether to show notifications when
+                                        changing sinks [$NOTIFICATIONS]
+  --osd | --no-osd                      whether to display KDE's OSD message
+                                        [$OSD]
+  --icon-muted <icon>                   icon to use when muted [none]
+  --icon-sink <icon>                    icon to use for sink [none]
+  --icons-volume <icon>[,<icon>...]     icons for volume, from lower to higher
+                                        [none]
+  --volume-max <int>                    maximum volume to which to allow
+                                        increasing [$VOLUME_MAX]
+  --volume-step <int>                   step size when inc/decrementing volume
+                                        [$VOLUME_INC]
+  --sink-blacklist <name>[,<name>...]   sinks to ignore when switching [none]
+  --sink-nicknames-from <prop>          pacmd property to use for sink names,
+                                        unless overriden by --sink-nickname.
+                                        Its possible values are listed under
+                                        the 'properties' key in the output of
+                                        \`pacmd list-sinks\` [none]
+  --sink-nickname <name>:<nick>         nickname to assign to given sink name,
+                                        taking priority over
+                                        --sink-nicknames-from. May be given
+                                        multiple times, and 'name' is exactly as
+                                        listed in the output of
+                                        \`pactl list sinks short | cut -f2\`
+                                        [none]
 
 Actions:
-    help              display this help and exit
-    output            print the PulseAudio status once
-    listen            listen for changes in PulseAudio to automatically update
-                      this script's output
-    up, down          increase or decrease the default sink's volume
-    mute, unmute      mute or unmute the default sink's audio
-    togmute           switch between muted and unmuted
-    next-sink         switch to the next available sink
-    sync              synchronize all the output streams volume to be the same
-                      as the current sink's volume
+  help              display this message and exit
+  output            print the PulseAudio status once
+  listen            listen for changes in PulseAudio to automatically update
+                    this script's output
+  up, down          increase or decrease the default sink's volume
+  mute, unmute      mute or unmute the default sink's audio
+  togmute           switch between muted and unmuted
+  next-sink         switch to the next available sink
+  sync              synchronize all the output streams volume to be the same as
+                    the current sink's volume
 
 Author:
     Mario Ortiz Manero

--- a/pulseaudio-control.bash
+++ b/pulseaudio-control.bash
@@ -325,6 +325,7 @@ function usage() {
     echo "Options:"
     echo "    --vol-icons       icons for volume, from lower to higher (comma-separated)"
     echo "    --vol-icon-mute   icon to use when muted"
+    echo "    --sink-blacklist  sinks to ignore when switching (comma-separated)"
     echo "    --sink-icon       icon to use for sink"
     echo "    --sink-name-from  pacmd property to use for sink name"
     echo "    --sink-nickname   <name>:<nick> pair to use for sink name (multiple args allowed)"
@@ -361,6 +362,9 @@ while [[ "$1" = --* ]]; do
     case "$arg" in
         --vol-icons)
             IFS=, read -r -a VOLUME_ICONS <<< "$val"
+            ;;
+        --sink-blacklist)
+            IFS=, read -r -a SINK_BLACKLIST <<< "$val"
             ;;
         --sink-icon)
             SINK_ICON="$val"

--- a/pulseaudio-control.bash
+++ b/pulseaudio-control.bash
@@ -349,14 +349,20 @@ function usage() {
 }
 
 while [[ "$1" = --* ]]; do
+    unset arg
+    unset val
     if [[ "$1" = *=* ]]; then
         arg="${1//=*/}"
         val="${1//*=/}"
         shift
     else
         arg="$1"
-        val="$2"
-        shift; shift
+        # Support space-separated values, but also value-less flags
+        if [[ "$2" != --* ]]; then
+            val="$2"
+            shift
+        fi
+        shift
     fi
 
     case "$arg" in

--- a/pulseaudio-control.bash
+++ b/pulseaudio-control.bash
@@ -323,9 +323,7 @@ function usage() {
     echo "Usage: $0 [OPTION...] ACTION"
     echo
     echo "Options:"
-    echo "    --vol-icon-low    icon to use at low volume"
-    echo "    --vol-icon-mid    icon to use at mid volume"
-    echo "    --vol-icon-high   icon to use at high volume"
+    echo "    --vol-icons       icons for volume, from lower to higher (comma-separated)"
     echo "    --vol-icon-mute   icon to use when muted"
     echo "    --sink-icon       icon to use for sink"
     echo "    --sink-name-from  pacmd property to use for sink name"
@@ -350,14 +348,8 @@ function usage() {
 
 while [[ "$1" = --* ]]; do
     case "$1" in
-        --vol-icon-low=*)
-            VOLUME_ICONS[0]="${1#--vol-icon-low=}"
-            ;;
-        --vol-icon-mid=*)
-            VOLUME_ICONS[1]="${1#--vol-icon-mid=}"
-            ;;
-        --vol-icon-high=*)
-            VOLUME_ICONS[2]="${1#--vol-icon-high=}"
+        --vol-icons=*)
+            IFS=, read -r -a VOLUME_ICONS <<< "${1#--vol-icons=}"
             ;;
         --sink-icon=*)
             SINK_ICON="${1#--sink-icon=}"

--- a/tests.bats
+++ b/tests.bats
@@ -35,8 +35,8 @@ function setup() {
 @test "nextSink()" {
     # This test will only work if there is currently only one sink. It's
     # kind of hardcoded to avoid excessive complexity.
-    pactl list short sinks
-    if [ "$(pactl list short sinks | wc -l)" -ne 1 ]; then
+    numSinks=$(pactl list short sinks | wc -l)
+    if [ "$numSinks" -ne 1 ]; then
         skip
     fi
 
@@ -76,16 +76,16 @@ function setup() {
 @test "volUp()" {
     # Increases the volume from zero to a set maximum step by step, making
     # sure that the results are expected.
-    MAX_VOL=350
-    INC=5
+    VOLUME_MAX=350
+    VOLUME_INC=5
     local vol=0
     getCurSink
     pactl set-sink-volume "$curSink" "$vol%"
     for i in {1..100}; do
         volUp
         getCurVol "$curSink"
-        if [ "$vol" -lt $MAX_VOL ]; then
-            vol=$((vol + INC))
+        if [ "$vol" -lt $VOLUME_MAX ]; then
+            vol=$((vol + VOLUME_INC))
         fi
         echo "Real volume is $curVol, expected $vol"
         [ "$curVol" -eq $vol ]
@@ -96,8 +96,8 @@ function setup() {
 @test "volDown()" {
     # Decreases the volume to 0 step by step, making sure that the results
     # are expected.
-    MAX_VOL=350
-    INC=5
+    VOLUME_MAX=350
+    VOLUME_INC=5
     # It shouldn't matter that the current volume exceeds the maximum volume
     local vol=375
     getCurSink
@@ -106,7 +106,7 @@ function setup() {
         volDown
         getCurVol "$curSink"
         if [ "$vol" -gt 0 ]; then
-            vol=$((vol - INC))
+            vol=$((vol - VOLUME_INC))
         fi
         echo "Real volume is $curVol, expected $vol"
         [ "$curVol" -eq $vol ]

--- a/tests.bats
+++ b/tests.bats
@@ -28,7 +28,7 @@ function restartPulseaudio() {
 function setup() {
     restartPulseaudio
     echo "Loading script"
-    source pulseaudio-control.bash --output &>/dev/null
+    source pulseaudio-control.bash output &>/dev/null
 }
 
 

--- a/tests.bats
+++ b/tests.bats
@@ -77,7 +77,7 @@ function setup() {
     # Increases the volume from zero to a set maximum step by step, making
     # sure that the results are expected.
     VOLUME_MAX=350
-    VOLUME_INC=5
+    VOLUME_STEP=5
     local vol=0
     getCurSink
     pactl set-sink-volume "$curSink" "$vol%"
@@ -85,7 +85,7 @@ function setup() {
         volUp
         getCurVol "$curSink"
         if [ "$vol" -lt $VOLUME_MAX ]; then
-            vol=$((vol + VOLUME_INC))
+            vol=$((vol + VOLUME_STEP))
         fi
         echo "Real volume is $curVol, expected $vol"
         [ "$curVol" -eq $vol ]
@@ -97,7 +97,7 @@ function setup() {
     # Decreases the volume to 0 step by step, making sure that the results
     # are expected.
     VOLUME_MAX=350
-    VOLUME_INC=5
+    VOLUME_STEP=5
     # It shouldn't matter that the current volume exceeds the maximum volume
     local vol=375
     getCurSink
@@ -106,7 +106,7 @@ function setup() {
         volDown
         getCurVol "$curSink"
         if [ "$vol" -gt 0 ]; then
-            vol=$((vol - VOLUME_INC))
+            vol=$((vol - VOLUME_STEP))
         fi
         echo "Real volume is $curVol, expected $vol"
         [ "$curVol" -eq $vol ]


### PR DESCRIPTION
For example:

    polybar-pulseaudio-control --sink-icon='⇉ ' \
      --sink-name-from='device.description' --vol-icon-low='🔈 ' \
      --vol-icon-mid='🔉 ' --vol-icon-high='🔊 ' listen



Towards #26. I haven't added options for everything since I thought it'd be better to get some early feedback, and, frankly, these are the ones that _I_ care about :smile:.

Sink nicknames from a pulseaudio property is a bit of a departure from the way it works setting within the file, but it seemed like it's be easier to use, and on my system at least has pretty usable results (to the point I almost want to suggest `device.description` as a default instead of numbers) - and perhaps there's a pulseaudio-wide way of overwriting descriptions (or other properties) that might be better than maintaining a separate list of polybar nicknames? Haven't looked into that yet.

In fact, it's surely possible, since I can change `device.description` & `bluez.alias` together for bluetooth devices by renaming them in `blueman`.