### PR TITLE
added ability to give nicknames to different ports

### DIFF
--- a/pulseaudio-control.bash
+++ b/pulseaudio-control.bash
@@ -44,7 +44,7 @@ function getCurVol() {
 # `sinkName`.
 function getSinkName() {
     sinkName=$(pactl list sinks short | awk -v sink="$1" '{ if ($1 == sink) {print $2} }')
-    portName=$(pacmd list-sinks | grep -e 'index' -e 'active port' | sed -n -e 's/<\(.*\)>/\1/' -e "/index: $curSink/,+1p" | awk '/active port:/{print $3}')
+    portName=$(pacmd list-sinks | grep -e 'index' -e 'active port' | sed -n -e 's/<\(.*\)>/\1/' -e "/index: $1/,+1p" | awk '/active port:/{print $3}')
 }
 
 

--- a/pulseaudio-control.bash
+++ b/pulseaudio-control.bash
@@ -44,6 +44,7 @@ function getCurVol() {
 # `sinkName`.
 function getSinkName() {
     sinkName=$(pactl list sinks short | awk -v sink="$1" '{ if ($1 == sink) {print $2} }')
+    portName=$(pacmd list-sinks | grep -e 'index' -e 'active port' | sed -n -e 's/<\(.*\)>/\1/' -e "/index: $curSink/,+1p" | awk '/active port:/{print $3}')
 }
 
 
@@ -55,7 +56,9 @@ function getNickname() {
     getSinkName "$1"
     unset SINK_NICKNAME
 
-    if [ -n "$sinkName" ] && [ -n "${SINK_NICKNAMES[$sinkName]}" ]; then
+    if [ -n "$sinkName" ] && [ -n "$portName" ] && [ -n "${SINK_NICKNAMES[$sinkName/$portName]}" ]; then
+        SINK_NICKNAME="${SINK_NICKNAMES[$sinkName/$portName]}"
+    elif [ -n "$sinkName" ] && [ -n "${SINK_NICKNAMES[$sinkName]}" ]; then
         SINK_NICKNAME="${SINK_NICKNAMES[$sinkName]}"
     elif [ -n "$sinkName" ] && [ -n "$SINK_NICKNAMES_PROP" ]; then
         getNicknameFromProp "$SINK_NICKNAMES_PROP" "$sinkName"


### PR DESCRIPTION
I added the ability to give nicknames to different ports. This is simmiliar to #32, but I think my version has several improvements.

First it is based upon current master.
Second it remains backwards compatible with the old `sinkname` format. The format for both a sinkname and a portname is `sinkname/portname`.
If a portname is specified, this rule takes precedence over rules with no portname specified.
There is one downside of my implementation though: the `sed` command uses syntax, which is only available in the GNU version of `sed`. (At least this is what it says in the manpage.) I don't know how big of an issue this is for you. I also couldn't really find a solution that uses less commands, but maybe an `awk` script would be good here, but I don't really know much `awk`.

I also haven't added any documentation for that yet, but that should not be a problem.