### PR TITLE
Fix buffering output delay

### DIFF
--- a/pulseaudio-control.bash
+++ b/pulseaudio-control.bash
@@ -292,9 +292,16 @@ function listen() {
     # This is faster than having the script on an interval.
     pactl subscribe 2>/dev/null | grep --line-buffered -e "on card" -e "on sink" -e "on server" | {
         while read -r; do
+            # Output the new state
+            output
+
             # Read all stdin to flush unwanted pending events, i.e. if there are
-            # 15 events at the same time (100ms window), output is called once.
+            # 15 events at the same time (100ms window), output is only called
+            # twice.
             read -r -d '' -t 0.1 -n 10000
+
+            # After the 100ms waiting time, output again the state, as it may
+            # have changed if the user did an action during the 100ms window.
             output
         done
     }


### PR DESCRIPTION
Events always come with multiple lines to process.
In order to process it once per event, do the following:

- Call output to display the changed state
- Wait 100ms to discard all the lines of the event
- Call output again to display the state (which could have changed if
  the user did an action within the 100ms window)

Before, we were always waiting 100ms after an event to display the
output. There was only one call to output, but late.

Without waiting for 100ms, we would be calling output too many times
for a single event.

Having two calls to output per 100ms is the best of the two solutions:
 there is responsiveness, and the number of calls is limited.