### PR TITLE
add option to disable color muted

### DIFF
--- a/pulseaudio-control.bash
+++ b/pulseaudio-control.bash
@@ -387,7 +387,12 @@ function output() {
     if [ "$IS_MUTED" = "yes" ]; then
         # shellcheck disable=SC2034
         VOL_ICON=$ICON_MUTED
-        echo "${COLOR_MUTED}$(eval echo "$FORMAT")${END_COLOR}"
+        content="$(eval echo "$FORMAT")"
+        if [ -n "$COLOR_MUTED" ]; then
+            echo "${COLOR_MUTED}${content}${END_COLOR}"
+        else
+            echo "$content"
+        fi
     else
         eval echo "$FORMAT"
     fi
@@ -406,6 +411,7 @@ Options:
         Default: \"$AUTOSYNC\"
   --color-muted <rrggbb>
         Color in which to format when muted.
+        Pass empty string to disable.
         Default: \"${COLOR_MUTED:4:-1}\"
   --notifications | --no-notifications
         Whether to show notifications when changing nodes.


### PR DESCRIPTION
This adds the option to pass an empty string to COLOR_MUTED to use color specified in polybar config.