### PR TITLE
Ability to view the battery charge of connected Bluetooth devices

### DIFF
--- a/README.md
+++ b/README.md
@@ -134,6 +134,25 @@ Options:
         can specify what timeout to use to control the responsiveness, in
         seconds.
         Default: "0.05"
+  --icons-bluetooth-battery <icon>[,<icon>...]
+        Icons for battery level of connected bluetooth headphones.
+        If no icons are provided, the feature is disabled.
+        Requires bluez experimental features to be enabled.
+        For details, see:
+          https://wiki.archlinux.org/title/Bluetooth_headset
+        Default: none
+  --hide-bluetooth-battery-level
+        Hide the integer battery level representation.
+        Requires bluez experimental features to be enabled.
+        For details, see:
+          https://wiki.archlinux.org/title/Bluetooth_headset
+        Default: none
+  --battery-max <int>
+        Set the maximum device battery level.
+        Requires bluez experimental features to be enabled.
+        For details, see:
+          https://wiki.archlinux.org/title/Bluetooth_headset
+        Default: \"$BAT_MAX\"
 
 Actions:
   help              display this message and exit

--- a/pulseaudio-control
+++ b/pulseaudio-control
@@ -22,11 +22,13 @@ OSD="no"
 NODE_NICKNAMES_PROP=
 VOLUME_STEP=2
 VOLUME_MAX=130
+BAT_MAX=100
 LISTEN_TIMEOUT=0.05
 # shellcheck disable=SC2016
 FORMAT='$VOL_ICON ${VOL_LEVEL}%  $ICON_NODE $NODE_NICKNAME'
 declare -A NODE_NICKNAMES
 declare -a ICONS_VOLUME
+declare -a ICONS_BLUETOOTH_BATTERY
 declare -a NODE_BLACKLIST
 
 # Special variable: within the script, pactl, grep, and awk commands are used
@@ -46,6 +48,8 @@ SINK_OR_SOURCE="ink"
 # Environment & global constants for the script
 export LC_ALL=C  # Some calls depend on English outputs of pactl
 END_COLOR="%{F-}"  # For Polybar colors
+BLUETOOTH_CONFIG="/etc/bluetooth/main.conf" # For Bluetooth configuration file
+BLUETOOTH_EXPERIMENTAL_REGEX="^Experimental = true" # Regex to tell whether battery level can be fetched
 
 
 # Saves the currently default node into a variable named `curNode`. It will
@@ -70,6 +74,22 @@ function getCurVol() {
 function getNodeName() {
     nodeName=$(pactl list "s${SINK_OR_SOURCE}s" short | awk -v sink="$1" "{ if (\$1 == sink) {print \$2} }")
     portName=$(pactl list "s${SINK_OR_SOURCE}s" | grep -e "S${SINK_OR_SOURCE} #" -e 'Active Port: ' | sed -n "/^S${SINK_OR_SOURCE} #$1\$/,+1p" | awk '/Active Port: / {print $3}')
+}
+
+
+# Saves the current battery level of a connected Bluetooth device for the node
+# passed by parameter into a variable named `BAT_LEVEL`.
+# If a node is not a Bluetooth device, `BAT_LEVEL` would be an empty string.
+# Requires bluez experimental features to be enabled.
+# For details, see: https://wiki.archlinux.org/title/Bluetooth_headset
+function getCurCharge() {
+    local bluetoothIsExperimental=$(grep -Eo "$BLUETOOTH_EXPERIMENTAL_REGEX" "$BLUETOOTH_CONFIG")
+    if [ "$bluetoothIsExperimental" ]; then
+        getNodeName "$1"
+
+        local bluetoothDeviceMac=$(echo "$nodeName" | sed -e 's/^[a-z_]*\.//' -e 's/\..*$//' | tr '_' ':')
+        BAT_LEVEL=$(bluetoothctl info "$bluetoothDeviceMac" | grep Battery | sed -E 's/.*\((.*)\)/\1/')
+    fi
 }
 
 
@@ -195,9 +215,9 @@ function volSync() {
         echo "PulseAudio not running"
         return 1
     fi
-    
+
     getCurVol "$curNode"
-    
+
     if [[ "$NODE_TYPE" = "output" ]]; then
         getSinkInputs "$curNode"
 
@@ -382,19 +402,38 @@ function output() {
     fi
 
     getNickname "$curNode"
+    getCurCharge "$curNode"
+
+    local iconsLen=${#ICONS_BLUETOOTH_BATTERY[@]}
+    if [ "$iconsLen" -ne 0 ] && [ "$BAT_LEVEL" != "" ]; then
+        local batSplit=$((BAT_MAX / iconsLen))
+        for i in $(seq 1 "$iconsLen"); do
+            if [ $((i * batSplit)) -ge "$BAT_LEVEL" ]; then
+                BAT_ICON="${ICONS_BLUETOOTH_BATTERY[$((i-1))]}"
+                break
+            fi
+        done
+
+        BLUETOOTH_FORMAT='$BAT_ICON ${BAT_LEVEL}%'
+        if [ "$HIDE_BAT" = "yes" ] && [ "$BAT_LEVEL" != '' ]; then
+            BLUETOOTH_FORMAT='$BAT_ICON'
+        fi
+    else
+        BLUETOOTH_FORMAT=''
+    fi
 
     # Showing the formatted message
     if [ "$IS_MUTED" = "yes" ]; then
         # shellcheck disable=SC2034
         VOL_ICON=$ICON_MUTED
-        content="$(eval echo "$FORMAT")"
+        content="$(eval echo "$FORMAT"  "$BLUETOOTH_FORMAT")"
         if [ -n "$COLOR_MUTED" ]; then
             echo "${COLOR_MUTED}${content}${END_COLOR}"
         else
             echo "$content"
         fi
     else
-        eval echo "$FORMAT"
+        eval echo "$FORMAT"  "$BLUETOOTH_FORMAT"
     fi
 }
 
@@ -484,6 +523,25 @@ Options:
         can specify what timeout to use to control the responsiveness, in
         seconds.
         Default: \"$LISTEN_TIMEOUT\"
+  --icons-bluetooth-battery <icon>[,<icon>...]
+        Icons for battery level of connected bluetooth headphones.
+        If no icons are provided, the feature is disabled.
+        Requires bluez experimental features to be enabled.
+        For details, see:
+          https://wiki.archlinux.org/title/Bluetooth_headset
+        Default: none
+  --hide-bluetooth-battery-level
+        Hide the integer battery level representation.
+        Requires bluez experimental features to be enabled.
+        For details, see:
+          https://wiki.archlinux.org/title/Bluetooth_headset
+        Default: none
+  --battery-max <int>
+        Set the maximum device battery level.
+        Requires bluez experimental features to be enabled.
+        For details, see:
+          https://wiki.archlinux.org/title/Bluetooth_headset
+        Default: \"$BAT_MAX\"
 
 Actions:
   help              display this message and exit
@@ -550,6 +608,17 @@ while [[ "$1" = --* ]]; do
             if getOptVal "$@"; then shift; fi
             # shellcheck disable=SC2034
             ICON_NODE="$val"
+            ;;
+        --hide-bluetooth-battery-level)
+            HIDE_BAT=yes
+            ;;
+        --icons-bluetooth-battery)
+            if getOptVal "$@"; then shift; fi
+            IFS=, read -r -a ICONS_BLUETOOTH_BATTERY <<< "${val//[[:space:]]/}"
+            ;;
+        --battery-max)
+            if getOptVal "$@"; then shift; fi
+            BAT_MAX="$val"
             ;;
         --icons-volume)
             if getOptVal "$@"; then shift; fi


### PR DESCRIPTION
Hello!

I have added new base functionality to view the battery charge of a connected Bluetooth device.

E.g.
`
~/repos/polybar-pulseaudio-control/pulseaudio-control.bash --color-muted "D75F87" --icons-volume ",奔,墳," --icon-muted "ﱝ" --node-nickname "alsa_output.pci-0000_00_1f.3-platform-skl_hda_dsp_generic.HiFi__hw_sofhdadsp__sink:ﰝ" --node-nickname "bluez_sink.68_D6_ED_8D_E9_D2.a2dp_sink:" **--icons-bluetooth-battery "ﴆ,ﴇ,ﴈ,ﴉ,ﴊ,ﴋ,ﴌ,ﴍ,ﴎ,ﴅ" --hide-bluetooth-battery-level listen**`

Produces the following output in my Polybar (I can now see the battery charge of my headphones).

![image](https://user-images.githubusercontent.com/38407640/198831049-563b39c3-05e9-4cec-b87c-680b5677ca55.png)

**This PR is pretty raw (needs additional refactoring and updates to tests).
I will make the adjustments, however I want to know whether such functionality would be welcome in this repo.**

Thank you very much in advance for your feedback!