### PR TITLE
Port stripped on white space (e.g., [Out] Speaker)

### DIFF
--- a/pulseaudio-control
+++ b/pulseaudio-control
@@ -69,7 +69,7 @@ function getCurVol() {
 # `nodeName`.
 function getNodeName() {
     nodeName=$(pactl list "s${SINK_OR_SOURCE}s" short | awk -v sink="$1" "{ if (\$1 == sink) {print \$2} }")
-    portName=$(pactl list "s${SINK_OR_SOURCE}s" | grep -e "S${SINK_OR_SOURCE} #" -e 'Active Port: ' | sed -n "/^S${SINK_OR_SOURCE} #$1\$/,+1p" | awk '/Active Port: / {print $3}')
+    portName=$(pactl list "s${SINK_OR_SOURCE}s" | grep -e "S${SINK_OR_SOURCE} #" -e 'Active Port: ' | sed -n "/^S${SINK_OR_SOURCE} #$1\$/,+1p" | awk -F ": " '/Active Port: / {print $2}')
 }
 
 


### PR DESCRIPTION
When the port is something like "[Out] Speaker" the previous awk call only extracted "[Out]". Now it extracts all fields. I'm not sure if the modified awk call is the best one can use but it works.

Fixes #83 