### PR TITLE
fix empty color muted from command line

### DIFF
--- a/pulseaudio-control
+++ b/pulseaudio-control
@@ -528,7 +528,11 @@ while [[ "$1" = --* ]]; do
             ;;
         --color-muted|--colour-muted)
             if getOptVal "$@"; then shift; fi
-            COLOR_MUTED="%{F#$val}"
+            if [ -n "$val" ]; then
+                COLOR_MUTED="%{F#$val}"
+            else
+                COLOR_MUTED=""
+            fi
             ;;
         --notifications)
             NOTIFICATIONS=yes


### PR DESCRIPTION
previously an empty value passed via --color-muted resulted in a broken COLOR_MUTED. Now it's just an empty string.